### PR TITLE
Lombok 의존성 제거 및 도메인 로직 리팩터링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,12 +29,11 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
 
-    implementation 'org.projectlombok:lombok'
-    annotationProcessor('org.projectlombok:lombok')
-
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/me/chan99k/learningmanager/domain/AbstractEntity.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/AbstractEntity.java
@@ -13,17 +13,15 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
-import lombok.Getter;
 
 /**
  * 생성/수정 시간 및 생성/수정 주체를 관리하기 위한 엔티티.
  * Instant 타입을 사용하여 타임존에 독립적으로 동작하도록 한다.
  */
-@Getter
+
 @MappedSuperclass
 public abstract class AbstractEntity {
 	@Id
-	@Getter(onMethod_ = {@Nullable})
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
@@ -31,13 +29,39 @@ public abstract class AbstractEntity {
 	@Column(nullable = false, updatable = false)
 	private Instant createdAt;
 
-	@LastModifiedDate
-	private Instant lastModifiedAt;
-
 	@CreatedBy
 	@Column(nullable = false, updatable = false)
 	private Long createdBy;
 
+	@LastModifiedDate
+	private Instant lastModifiedAt;
+
 	@LastModifiedBy
 	private Long lastModifiedBy;
+
+	/**
+	 * 엔티티의 고유 식별자를 반환합니다.
+	 * 다만, 엔티티가 아직 영속화 되지 않았다면 null 을 반환할 수도 있습니다.
+	 * @return ID 또는 null
+	 */
+	@Nullable
+	public Long getId() {
+		return id;
+	}
+
+	public Instant getCreatedAt() {
+		return createdAt;
+	}
+
+	public Instant getLastModifiedAt() {
+		return lastModifiedAt;
+	}
+
+	public Long getCreatedBy() {
+		return createdBy;
+	}
+
+	public Long getLastModifiedBy() {
+		return lastModifiedBy;
+	}
 }

--- a/src/main/java/me/chan99k/learningmanager/domain/attendance/Attendance.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/attendance/Attendance.java
@@ -6,14 +6,10 @@ import java.time.Instant;
 import java.util.Objects;
 
 import jakarta.persistence.Entity;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import me.chan99k.learningmanager.domain.AbstractEntity;
 
-@Getter
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+
 public class Attendance extends AbstractEntity {
 
 	private Long sessionId;
@@ -46,5 +42,21 @@ public class Attendance extends AbstractEntity {
 
 		// checkOutTime이 checkInTime 보다 늦는지 검증
 		isTrue(this.checkOutTime.isAfter(this.checkInTime), "[System] 퇴실 시간은 입실 시간보다 빠를 수 없습니다.");
+	}
+
+	public Long getSessionId() {
+		return sessionId;
+	}
+
+	public Long getMemberId() {
+		return memberId;
+	}
+
+	public Instant getCheckInTime() {
+		return checkInTime;
+	}
+
+	public Instant getCheckOutTime() {
+		return checkOutTime;
 	}
 }

--- a/src/main/java/me/chan99k/learningmanager/domain/course/CourseMember.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/course/CourseMember.java
@@ -8,14 +8,10 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import me.chan99k.learningmanager.domain.AbstractEntity;
 
-@Getter
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+
 public class CourseMember extends AbstractEntity {
 	/**
 	 * 사용자 ID
@@ -53,4 +49,17 @@ public class CourseMember extends AbstractEntity {
 		this.courseRole = newRole;
 	}
 
+	/* 게터 로직 */
+
+	public Long getMemberId() {
+		return memberId;
+	}
+
+	public Course getCourse() {
+		return course;
+	}
+
+	public CourseRole getCourseRole() {
+		return courseRole;
+	}
 }

--- a/src/main/java/me/chan99k/learningmanager/domain/course/Curriculum.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/course/Curriculum.java
@@ -2,20 +2,13 @@ package me.chan99k.learningmanager.domain.course;
 
 import static org.springframework.util.Assert.*;
 
-import org.springframework.util.StringUtils;
-
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import me.chan99k.learningmanager.domain.AbstractEntity;
 
-@Getter
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Curriculum extends AbstractEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)
@@ -39,12 +32,27 @@ public class Curriculum extends AbstractEntity {
 		return curriculum;
 	}
 
-	public void update(String title, String description) {
-		if (StringUtils.hasText(title)) {
-			this.title = title;
-		}
-		if (description != null) {
-			this.description = description;
-		}
+	public void updateTitle(String newTitle) {
+		hasText(newTitle, "[System] 커리큘럼명 값이 비어 있습니다.");
+		this.title = newTitle;
+	}
+
+	public void updateDescription(String newDescription) {
+		hasText(newDescription, "[System] 커리큘럼에 대한 설명 값이 비어 있습니다.");
+		this.description = newDescription;
+	}
+
+	/* 게터 로직 */
+
+	public Course getCourse() {
+		return course;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public String getDescription() {
+		return description;
 	}
 }

--- a/src/main/java/me/chan99k/learningmanager/domain/member/Account.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/member/Account.java
@@ -11,14 +11,9 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import me.chan99k.learningmanager.domain.AbstractEntity;
 
-@Getter
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Account extends AbstractEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id", nullable = false)
@@ -63,4 +58,19 @@ public class Account extends AbstractEntity {
 		this.status = AccountStatus.INACTIVE;
 	}
 
+	public Member getMember() {
+		return member;
+	}
+
+	public AccountStatus getStatus() {
+		return status;
+	}
+
+	public Email getEmail() {
+		return email;
+	}
+
+	public Password getPassword() {
+		return password;
+	}
 }

--- a/src/main/java/me/chan99k/learningmanager/domain/member/Member.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/member/Member.java
@@ -8,14 +8,9 @@ import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import me.chan99k.learningmanager.domain.AbstractEntity;
 
-@Getter
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends AbstractEntity {
 
 	@Embedded
@@ -85,5 +80,25 @@ public class Member extends AbstractEntity {
 	public void unban() {
 		state(this.status == MemberStatus.BANNED, "이용 정지 상태의 회원만 해제될 수 있습니다.");
 		this.status = MemberStatus.ACTIVE;
+	}
+
+	public Nickname getNickname() {
+		return nickname;
+	}
+
+	public SystemRole getRole() {
+		return role;
+	}
+
+	public MemberStatus getStatus() {
+		return status;
+	}
+
+	public String getProfileImageUrl() {
+		return profileImageUrl;
+	}
+
+	public String getSelfIntroduction() {
+		return selfIntroduction;
 	}
 }

--- a/src/main/java/me/chan99k/learningmanager/domain/session/Session.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/session/Session.java
@@ -21,11 +21,9 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import lombok.Getter;
 import me.chan99k.learningmanager.domain.AbstractEntity;
 
 @Entity
-@Getter
 public class Session extends AbstractEntity {
 	@Column(name = "course_id")
 	private Long courseId;
@@ -124,7 +122,7 @@ public class Session extends AbstractEntity {
 			.anyMatch(p -> p.getMemberId().equals(memberId));
 		isTrue(!alreadyExists, "[System] 이미 세션에 참여 중인 멤버입니다.");
 
-		SessionParticipant participant = SessionParticipant.of(this, memberId, role);
+		SessionParticipant participant = SessionParticipant.of(memberId, this, role);
 		this.participants.add(participant);
 	}
 
@@ -201,6 +199,14 @@ public class Session extends AbstractEntity {
 		}
 	}
 
+	public Instant getScheduledAt() {
+		return scheduledAt;
+	}
+
+	public Instant getScheduledEndAt() {
+		return scheduledEndAt;
+	}
+
 	public List<SessionParticipant> getParticipants() {
 		return Collections.unmodifiableList(this.participants);
 	}
@@ -211,5 +217,37 @@ public class Session extends AbstractEntity {
 
 	boolean isChildSession() {
 		return !this.isRootSession();
+	}
+
+	public Long getCourseId() {
+		return courseId;
+	}
+
+	public Long getCurriculumId() {
+		return curriculumId;
+	}
+
+	public Session getParent() {
+		return parent;
+	}
+
+	public List<Session> getChildren() {
+		return children;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public SessionType getType() {
+		return type;
+	}
+
+	public SessionLocation getLocation() {
+		return location;
+	}
+
+	public String getLocationDetails() {
+		return locationDetails;
 	}
 }

--- a/src/main/java/me/chan99k/learningmanager/domain/session/Session.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/session/Session.java
@@ -41,6 +41,7 @@ public class Session extends AbstractEntity {
 	@OneToMany(mappedBy = "session", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<SessionParticipant> participants = new ArrayList<>();
 
+	@Column(nullable = false)
 	private String title;
 
 	private Instant scheduledAt;
@@ -55,26 +56,27 @@ public class Session extends AbstractEntity {
 
 	private String locationDetails;
 
-	// TODO :: 담당 매니저,멘토가 같으면서 루트/하위 세션 타입도 같은 세션은 서로 시간이 겹치면 안된다는 제약 조건을 추가하여야 함
-	/* Domain Logic */
+	protected Session() {
+	}
 
-	private static Session create(String title, Instant scheduledAt, Instant scheduledEndAt,
+	private Session(String title, Instant scheduledAt, Instant scheduledEndAt,
 		SessionType type, SessionLocation location, String locationDetails
 	) {
-		Session session = new Session();
-		session.title = title;
-		session.scheduledAt = scheduledAt;
-		session.scheduledEndAt = scheduledEndAt;
-		session.type = type;
-		session.location = location;
-		session.locationDetails = locationDetails;
-		return session;
+		this.title = title;
+		this.scheduledAt = scheduledAt;
+		this.scheduledEndAt = scheduledEndAt;
+		this.type = type;
+		this.location = location;
+		this.locationDetails = locationDetails;
 	}
+
+	// TODO :: 담당 매니저,멘토가 같으면서 루트/하위 세션 타입도 같은 세션은 서로 시간이 겹치면 안된다는 제약 조건을 추가하여야 함
+	/* Domain Logic */
 
 	public static Session createStandaloneSession(String title, Instant scheduledAt, Instant scheduledEndAt,
 		SessionType type, SessionLocation location, String locationDetails
 	) {
-		Session session = create(title, scheduledAt, scheduledEndAt, type, location, locationDetails);
+		Session session = new Session(title, scheduledAt, scheduledEndAt, type, location, locationDetails);
 		session.validate();
 		return session;
 	}
@@ -84,7 +86,7 @@ public class Session extends AbstractEntity {
 		SessionType type, SessionLocation location, String locationDetails
 	) {
 		notNull(courseId, "[System] 코스 ID는 필수입니다.");
-		Session session = create(title, scheduledAt, scheduledEndAt, type, location, locationDetails);
+		Session session = new Session(title, scheduledAt, scheduledEndAt, type, location, locationDetails);
 		session.courseId = courseId;
 		session.validate();
 		return session;
@@ -94,7 +96,7 @@ public class Session extends AbstractEntity {
 		Instant scheduledEndAt, SessionType type, SessionLocation location, String locationDetails) {
 		notNull(courseId, "[System] 코스 ID는 필수입니다.");
 		notNull(curriculumId, "[System] 커리큘럼 ID는 필수입니다.");
-		Session session = create(title, scheduledAt, scheduledEndAt, type, location, locationDetails);
+		Session session = new Session(title, scheduledAt, scheduledEndAt, type, location, locationDetails);
 		session.courseId = courseId;
 		session.curriculumId = curriculumId;
 		session.validate();
@@ -106,7 +108,7 @@ public class Session extends AbstractEntity {
 	) {
 		isTrue(this.isRootSession(), "[System] 하위 세션은 또 다른 하위 세션을 가질 수 없습니다.");
 
-		Session child = create(title, scheduledAt, scheduledEndAt, type, location, locationDetails);
+		Session child = new Session(title, scheduledAt, scheduledEndAt, type, location, locationDetails);
 		child.parent = this;
 		// 하위 세션은 부모의 소속(코스, 커리큘럼)을 상속
 		child.courseId = this.courseId;
@@ -127,23 +129,61 @@ public class Session extends AbstractEntity {
 	}
 
 	public void removeParticipant(Long memberId) {
-		this.participants.removeIf(p -> p.getMemberId().equals(memberId));
+		boolean removed = this.participants.removeIf(p -> p.getMemberId().equals(memberId));
+		isTrue(removed, "[System] 해당 세션에 참여하지 않는 멤버입니다.");
 	}
 
-	public void update(String title, Instant scheduledAt,
-		Instant scheduledEndAt, SessionType type,
-		SessionLocation location, String locationDetails
-	) {
-
+	public void changeParticipantRole(Long memberId, SessionParticipantRole newRole) {
+		// 수정 가능 여부를 먼저 검증
 		validateUpdatable();
 
-		this.title = title;
-		this.scheduledAt = scheduledAt;
-		this.scheduledEndAt = scheduledEndAt;
-		this.type = type;
-		this.location = location;
-		this.locationDetails = locationDetails;
+		// 역할 변경에 대한 비즈니스 규칙 검증
+		// -> HOST는 세션에 한 명만 존재해야 한다
+		if (newRole == SessionParticipantRole.HOST) {
+			boolean anotherHostExists = this.participants.stream()
+				.anyMatch(p -> p.getRole() == SessionParticipantRole.HOST && !p.getMemberId().equals(memberId));
+			isTrue(!anotherHostExists, "[System] 세션에는 한 명의 호스트만 지정할 수 있습니다.");
+		}
 
+		// 대상 참여자를 찾아서 실제 역할 변경을 위임
+		SessionParticipant participant = findParticipant(memberId);
+		participant.changeRole(newRole);
+	}
+
+	private SessionParticipant findParticipant(Long memberId) {
+		return this.participants.stream()
+			.filter(p -> p.getMemberId().equals(memberId))
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("[System] 해당 세션에 참여하지 않는 멤버입니다."));
+	}
+
+	/**
+	 * 세션의 시간을 재조정합니다.
+	 */
+	public void reschedule(Instant newScheduledAt, Instant newScheduledEndAt) {
+		validateUpdatable();
+		this.scheduledAt = newScheduledAt;
+		this.scheduledEndAt = newScheduledEndAt;
+		validate();
+	}
+
+	/**
+	 * 세션의 기본 정보를 변경합니다.
+	 */
+	public void changeInfo(String newTitle, SessionType newType) {
+		validateUpdatable();
+		this.title = newTitle;
+		this.type = newType;
+		validate();
+	}
+
+	/**
+	 * 세션의 장소를 변경합니다.
+	 */
+	public void changeLocation(SessionLocation newLocation, String newLocationDetails) {
+		validateUpdatable();
+		this.location = newLocation;
+		this.locationDetails = newLocationDetails;
 		validate();
 	}
 

--- a/src/main/java/me/chan99k/learningmanager/domain/session/SessionParticipant.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/session/SessionParticipant.java
@@ -45,11 +45,13 @@ public class SessionParticipant extends AbstractEntity {
 		return memberId;
 	}
 
-	public Session getSession() {
-		return session;
-	}
-
 	public SessionParticipantRole getRole() {
 		return role;
+	}
+
+	public void changeRole(SessionParticipantRole newRole) {
+		notNull(newRole, "[System] 새로운 역할은 null일 수 없습니다.");
+		isTrue(this.role != newRole, "[System] 이미 해당 역할을 가지고 있습니다.");
+		this.role = newRole;
 	}
 }

--- a/src/main/java/me/chan99k/learningmanager/domain/session/SessionParticipant.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/session/SessionParticipant.java
@@ -9,37 +9,47 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import me.chan99k.learningmanager.domain.AbstractEntity;
 
 @Entity
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SessionParticipant extends AbstractEntity {
+	@Column(nullable = false)
+	private Long memberId;
+
 	@ManyToOne(fetch = FetchType.LAZY, optional = false)
 	@JoinColumn(name = "session_id")
 	private Session session;
-
-	@Column(nullable = false)
-	private Long memberId;
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private SessionParticipantRole role;
 
-	private SessionParticipant(Session session, Long memberId, SessionParticipantRole role) {
+	public SessionParticipant() {
+	}
+
+	private SessionParticipant(Long memberId, Session session, SessionParticipantRole role) {
 		this.session = session;
 		this.memberId = memberId;
 		this.role = role;
 	}
 
-	public static SessionParticipant of(Session session, Long memberId, SessionParticipantRole role) {
+	public static SessionParticipant of(Long memberId, Session session, SessionParticipantRole role) {
 		notNull(session, "[System] Session 은 null 일 수 없습니다.");
 		notNull(memberId, "[System] Member ID 는 null 일 수 없습니다.");
 		notNull(role, "[System] Role 은 null 일 수 없습니다.");
 
-		return new SessionParticipant(session, memberId, role);
+		return new SessionParticipant(memberId, session, role);
+	}
+
+	public Long getMemberId() {
+		return memberId;
+	}
+
+	public Session getSession() {
+		return session;
+	}
+
+	public SessionParticipantRole getRole() {
+		return role;
 	}
 }

--- a/src/test/java/me/chan99k/learningmanager/domain/course/CurriculumTest.java
+++ b/src/test/java/me/chan99k/learningmanager/domain/course/CurriculumTest.java
@@ -37,15 +37,41 @@ class CurriculumTest {
 		}
 
 		@Test
-		@DisplayName("[Success] 커리큘럼의 제목과 설명을 성공적으로 수정한다.")
+		@DisplayName("[Success] 커리큘럼의 제목을 성공적으로 수정한다.")
 		void update_curriculum_success() {
-			String newTitle = "수정된 커리큘럼";
-			String newDescription = "Spring 심화";
+			String newTitle = "수정된 커리큘럼 제목";
 
-			curriculum.update(newTitle, newDescription);
+			curriculum.updateTitle(newTitle);
 
 			assertThat(curriculum.getTitle()).isEqualTo(newTitle);
+		}
+
+		@Test
+		@DisplayName("[Success] 커리큘럼의 설명을 성공적으로 수정한다.")
+		void update_curriculum_description_success() {
+			String newDescription = "수정된 커리큘럼 설명";
+
+			curriculum.updateDescription(newDescription);
+
 			assertThat(curriculum.getDescription()).isEqualTo(newDescription);
+		}
+
+		@Test
+		@DisplayName("[Failure] 커리큘럼 제목이 비어있으면 수정에 실패한다")
+		void fail_to_update_course_when_title_is_null() {
+
+			assertThatThrownBy(() -> curriculum.updateTitle(null))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("[System] 커리큘럼명 값이 비어 있습니다.");
+		}
+
+		@Test
+		@DisplayName("[Failure] 커리큘럼 설명이 비어있으면 수정에 실패한다")
+		void fail_to_update_course_when_description_is_null() {
+
+			assertThatThrownBy(() -> curriculum.updateDescription(null))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("[System] 커리큘럼에 대한 설명 값이 비어 있습니다.");
 		}
 	}
 }

--- a/src/test/java/me/chan99k/learningmanager/domain/member/AccountTest.java
+++ b/src/test/java/me/chan99k/learningmanager/domain/member/AccountTest.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class AccountTest {
@@ -29,22 +30,99 @@ class AccountTest {
 
 	}
 
-	@Test
-	@DisplayName("[Success] 올바른 정보로 계정을 생성하는 데 성공한다")
-	void create_account_succeeds() {
-		Account account = Account.create(member, "test@example.com", "ValidPass123!", passwordEncoder);
+	@Nested
+	@DisplayName("계정 생성 테스트")
+	class AccountCreationTest {
+		@Test
+		@DisplayName("[Success] 올바른 정보로 계정을 생성하는 데 성공한다")
+		void create_account_succeeds() {
+			Account account = Account.create(member, "test@example.com", "ValidPass123!", passwordEncoder);
 
-		assertThat(account.getMember()).isEqualTo(member);
-		assertThat(account.getEmail().address()).isEqualTo("test@example.com");
-		assertThat(account.getStatus()).isEqualTo(AccountStatus.PENDING);
+			assertThat(account.getMember()).isEqualTo(member);
+			assertThat(account.getEmail().address()).isEqualTo("test@example.com");
+			assertThat(account.getStatus()).isEqualTo(AccountStatus.PENDING);
+		}
+
+		@Test
+		@DisplayName("[Failure] memberId 없이 account를 생성하려 하면 예외가 발생한다")
+		void create_account_with_null_memberId_throws_exception() {
+			assertThatThrownBy(() -> Account.create(null, "test@example.com", "ValidPass123!", passwordEncoder))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("[System] 계정은 반드시 멤버에 속해야 합니다.");
+		}
+
 	}
 
-	@Test
-	@DisplayName("[Failure] memberId 없이 account를 생성하려 하면 예외가 발생한다")
-	void create_account_with_null_memberId_throws_exception() {
-		assertThatThrownBy(() -> Account.create(null, "test@example.com", "ValidPass123!", passwordEncoder))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("[System] 계정은 반드시 멤버에 속해야 합니다.");
+	@Nested
+	@DisplayName("계정 정보 관리 테스트")
+	class AccountManagementTest {
+		Account account;
+
+		@BeforeEach
+		void setUp() {
+			account = Account.create(member, "chan99k@example.com", "deprecatingPassword123!", passwordEncoder);
+		}
+
+		@Test
+		@DisplayName("[Success] 기존 비밀번호를 새로운 비밀번호로 바꾸는 데 성공한다.")
+		void success_to_changePassword() {
+			String oldPassword = account.getPassword().encoded();
+			String newPassword = "newPassword123!";
+
+			account.changePassword(newPassword, passwordEncoder);
+
+			assertThat(account.getPassword().encoded()).isNotEqualTo(oldPassword);
+
+		}
+
+		@Test
+		@DisplayName("[Success] 계정 사용을 활성화하는데 성공한다.")
+		void success_to_activate_account() {
+			assertThat(account.getStatus()).isEqualTo(AccountStatus.PENDING);
+
+			account.activate();
+
+			assertThat(account.getStatus()).isEqualTo(AccountStatus.ACTIVE);
+		}
+
+		@Test
+		@DisplayName("[Failure] 활성 상태의 계정이라면 활성화에 실패한다.")
+		void fail_to_activate_account_when_status_is_not_pending_or_inactive() {
+			account.activate();
+
+			assertThatThrownBy(account::activate)
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessage("[System] 활성 대기/비활성 상태의 계정이 아닙니다.");
+		}
+
+		@Test
+		@DisplayName("[Failure] 비활성 상태의 계정이라면 활성화에 실패한다.")
+		void fail_to_activate_account_when_status_is_not_inactive() {
+			account.activate();
+
+			assertThatThrownBy(account::activate)
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessage("[System] 활성 대기/비활성 상태의 계정이 아닙니다.");
+		}
+
+		@Test
+		@DisplayName("[Success] 계정을 비활성화 하는데 성공한다.")
+		void success_to_deactivate_account() {
+			account.activate();
+
+			account.deactivate();
+
+			assertThat(account.getStatus()).isEqualTo(AccountStatus.INACTIVE);
+		}
+
+		@Test
+		@DisplayName("[Failure] 활성 상태의 계정이 아니라면 비활성화에 실패한다.")
+		void fail_to_deactivate_account() {
+
+			assertThatThrownBy(account::deactivate)
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessage("[System] 활성 상태의 계정이 아닙니다.");
+		}
 	}
 
 }

--- a/src/test/java/me/chan99k/learningmanager/domain/member/MemberTest.java
+++ b/src/test/java/me/chan99k/learningmanager/domain/member/MemberTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 class MemberTest {
 
@@ -22,6 +23,13 @@ class MemberTest {
 	@Nested
 	@DisplayName("회원 관리 테스트")
 	class MemberCreationTEst {
+		@Test
+		@DisplayName("[Success] 회원 ID 반환에 성공한다.")
+		void success_to_return_memberId() {
+			ReflectionTestUtils.setField(member, "id", 1L);
+			assertThat(member.getId()).isNotNull();
+		}
+
 		@Test
 		@DisplayName("[Success] 프로필 업데이트에 성공한다.")
 		void success_to_update_profile() {
@@ -87,11 +95,11 @@ class MemberTest {
 		@Test
 		@DisplayName("[Success] 휴면 상태인 회원을 활성화하는데 성공한다")
 		void success_to_activate_member() {
-		    member.deactivate(); // 휴면 상태로 변경
-		    assertThat(member.getStatus()).isEqualTo(MemberStatus.INACTIVE);
+			member.deactivate(); // 휴면 상태로 변경
+			assertThat(member.getStatus()).isEqualTo(MemberStatus.INACTIVE);
 
-		    member.activate();
-		    assertThat(member.getStatus()).isEqualTo(MemberStatus.ACTIVE);
+			member.activate();
+			assertThat(member.getStatus()).isEqualTo(MemberStatus.ACTIVE);
 		}
 
 		@Test

--- a/src/test/java/me/chan99k/learningmanager/domain/member/PasswordTest.java
+++ b/src/test/java/me/chan99k/learningmanager/domain/member/PasswordTest.java
@@ -1,12 +1,11 @@
 package me.chan99k.learningmanager.domain.member;
 
+import static org.assertj.core.api.Assertions.*;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PasswordTest {
 
@@ -25,6 +24,29 @@ class PasswordTest {
     @DisplayName("[Success] 올바른 형식의 비밀번호로 객체를 생성하는 데 성공한다")
     void create_password_with_valid_format() {
         assertThatCode(() -> Password.generatePassword("ValidPass1!", passwordEncoder)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("[Success] 올바른 비밀번호로 검증 시 true를 반환한다")
+    void verify_success_with_correct_password() {
+        String rawPassword = "CorrectPassword1!";
+        Password password = Password.generatePassword(rawPassword, passwordEncoder);
+
+        boolean result = password.verify(rawPassword, passwordEncoder);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("[Failure] 틀린 비밀번호로 검증 시 false를 반환한다")
+    void verify_failure_with_incorrect_password() {
+        String rawPassword = "CorrectPassword1!";
+        String wrongPassword = "WrongPassword1!";
+        Password password = Password.generatePassword(rawPassword, passwordEncoder);
+
+        boolean result = password.verify(wrongPassword, passwordEncoder);
+
+        assertThat(result).isFalse();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## 💡 Motivation and Context
> 이 PR은 프로젝트에서 Lombok 의존성을 제거합니다. 또한 도메인 로직을 리팩터링하고 테스트 커버리지를 개선합니다.

<br>

## 🔨 Modified
- Lombok 의존성을 제거했습니다:
    - 롬복 제거에 따라 도메인 로직을 업데이트하고 관련 코드를 조정했습니다.
    - Lombok 제거를 반영하여 테스트 코드를 업데이트했습니다.
- Session 도메인 로직을 리팩터링했습니다
  - Session 생성자를 업데이트하고 불필요한 로직을 제거했습니다.
  - 참여자 역할 변경에 대한 유효성 검사를 추가했습니다.
  - 시간 및 장소와 같은 세션 상세 정보를 업데이트하는 메서드를 분리했습니다.
  - SessionParticipant에 역할 변경을 위한 메서드를 추가했습니다.
- Password 에 대하여,
  - verify() 메서드에 대한 누락된 테스트를 추가했습니다


<br>

## 🌟 More
> _추가적인 코드베이스 정리가 필요할 수 있습니다._

<br>

---


### 📋 체크리스트
- [x] 추가/변경에 대한 테스트
- [x] 코드 컨벤션

<br>

### 🤟🏻 PR로 완료된 이슈
> closes #21