### PR TITLE
각 도메인 별 예외 메시지 중앙화

### DIFF
--- a/src/main/java/me/chan99k/learningmanager/common/exception/ProblemCode.java
+++ b/src/main/java/me/chan99k/learningmanager/common/exception/ProblemCode.java
@@ -1,0 +1,7 @@
+package me.chan99k.learningmanager.common.exception;
+
+public interface ProblemCode {
+	String getCode();
+
+	String getMessage();
+}

--- a/src/main/java/me/chan99k/learningmanager/domain/attendance/Attendance.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/attendance/Attendance.java
@@ -1,5 +1,6 @@
 package me.chan99k.learningmanager.domain.attendance;
 
+import static me.chan99k.learningmanager.domain.attendance.AttendanceProblemCode.*;
 import static org.springframework.util.Assert.*;
 
 import java.time.Instant;
@@ -23,8 +24,8 @@ public class Attendance extends AbstractEntity {
 	/* 도메인 로직 */
 
 	public static Attendance checkIn(Long sessionId, Long memberId) {
-		notNull(sessionId, "[System] 출석을 기록할 세션은 필수입니다.");
-		notNull(memberId, "[System] 출석을 기록할 회원은 필수입니다.");
+		notNull(sessionId, SESSION_ID_REQUIRED.getMessage());
+		notNull(memberId, MEMBER_ID_REQUIRED.getMessage());
 
 		Attendance attendance = new Attendance();
 		attendance.sessionId = sessionId;
@@ -36,12 +37,12 @@ public class Attendance extends AbstractEntity {
 	}
 
 	public void checkOut() {
-		state(Objects.isNull(checkOutTime), "[System] 이미 퇴실 처리된 출석 기록입니다.");
+		state(Objects.isNull(checkOutTime), ALREADY_CHECKED_OUT.getMessage());
 
 		this.checkOutTime = Instant.now();
 
 		// checkOutTime이 checkInTime 보다 늦는지 검증
-		isTrue(this.checkOutTime.isAfter(this.checkInTime), "[System] 퇴실 시간은 입실 시간보다 빠를 수 없습니다.");
+		isTrue(this.checkOutTime.isAfter(this.checkInTime), CHECK_OUT_TIME_BEFORE_CHECK_IN_TIME.getMessage());
 	}
 
 	public Long getSessionId() {

--- a/src/main/java/me/chan99k/learningmanager/domain/attendance/AttendanceProblemCode.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/attendance/AttendanceProblemCode.java
@@ -1,0 +1,28 @@
+package me.chan99k.learningmanager.domain.attendance;
+
+import me.chan99k.learningmanager.common.exception.ProblemCode;
+
+public enum AttendanceProblemCode implements ProblemCode {
+	SESSION_ID_REQUIRED("DAL001", "[System] 출석을 기록할 세션은 필수입니다."),
+	MEMBER_ID_REQUIRED("DAL002", "[System] 출석을 기록할 회원은 필수입니다."),
+	ALREADY_CHECKED_OUT("DAL003", "[System] 이미 퇴실 처리된 출석 기록입니다."),
+	CHECK_OUT_TIME_BEFORE_CHECK_IN_TIME("DAL004", "[System] 퇴실 시간은 입실 시간보다 빠를 수 없습니다.");
+
+	private final String code;
+	private final String message;
+
+	AttendanceProblemCode(String code, String message) {
+		this.code = code;
+		this.message = message;
+	}
+
+	@Override
+	public String getCode() {
+		return code;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/main/java/me/chan99k/learningmanager/domain/course/Course.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/course/Course.java
@@ -1,5 +1,6 @@
 package me.chan99k.learningmanager.domain.course;
 
+import static me.chan99k.learningmanager.domain.course.CourseProblemCode.*;
 import static org.springframework.util.Assert.*;
 
 import java.util.ArrayList;
@@ -29,7 +30,7 @@ public class Course extends AbstractEntity {
 	/* 도메인 로직 */
 
 	public static Course create(String title, String description) {
-		hasText(title, "[시스템] 과정명은 필수값 입니다.");
+		hasText(title, COURSE_TITLE_REQUIRED.getMessage());
 
 		Course course = new Course();
 		course.title = title;
@@ -38,12 +39,12 @@ public class Course extends AbstractEntity {
 	}
 
 	public void updateTitle(String newTitle) {
-		hasText(newTitle, "[System] 과정명 값이 비어 있습니다.");
+		hasText(newTitle, COURSE_TITLE_REQUIRED.getMessage());
 		this.title = newTitle;
 	}
 
 	public void updateDescription(String newDescription) {
-		hasText(newDescription, "[System] 과정에 대한 설명 값이 비어 있습니다.");
+		hasText(newDescription, COURSE_DESCRIPTION_REQUIRED.getMessage());
 		this.description = newDescription;
 	}
 
@@ -52,7 +53,7 @@ public class Course extends AbstractEntity {
 			member -> member.getMemberId().equals(memberId)
 		);
 
-		isTrue(!alreadyExists, "[System] 이미 과정에 등록된 멤버입니다.");
+		isTrue(!alreadyExists, COURSE_MEMBER_ALREADY_REGISTERED.getMessage());
 
 		CourseMember courseMember = CourseMember.enroll(this, memberId, courseRole);
 		this.courseMemberList.add(courseMember);
@@ -63,7 +64,7 @@ public class Course extends AbstractEntity {
 			courseMember -> courseMember.getMemberId().equals(memberId)
 		);
 
-		isTrue(removed, "[System] 과정에 등록되지 않은 멤버입니다.");
+		isTrue(removed, COURSE_MEMBER_NOT_REGISTERED.getMessage());
 	}
 
 	public void addCurriculum(String title, String description) {
@@ -73,11 +74,11 @@ public class Course extends AbstractEntity {
 	}
 
 	public void removeCurriculum(Curriculum curriculum) {
-		notNull(curriculum, "[System] 제거할 커리큘럼은 null일 수 없습니다.");
+		notNull(curriculum, CURRICULUM_NULL.getMessage());
 
 		boolean removed = this.curriculumList.remove(curriculum);
 
-		isTrue(removed, "[System] 해당 과정에 존재하지 않는 커리큘럼입니다. ID: " + curriculum.getId());
+		isTrue(removed, CURRICULUM_NOT_FOUND_IN_COURSE.getMessage() + " ID: " + curriculum.getId());
 	}
 
 	/* 게터 로직 */

--- a/src/main/java/me/chan99k/learningmanager/domain/course/CourseMember.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/course/CourseMember.java
@@ -1,5 +1,6 @@
 package me.chan99k.learningmanager.domain.course;
 
+import static me.chan99k.learningmanager.domain.course.CourseProblemCode.*;
 import static org.springframework.util.Assert.*;
 
 import jakarta.persistence.Entity;
@@ -32,9 +33,9 @@ public class CourseMember extends AbstractEntity {
 	/* 도메인 로직 */
 
 	public static CourseMember enroll(Course course, Long memberId, CourseRole courseRole) {
-		notNull(course, "[System] 코스는 필수입니다.");
-		notNull(memberId, "[System] 멤버 ID는 필수입니다.");
-		notNull(courseRole, "[System] 코스 역할은 필수입니다.");
+		notNull(course, COURSE_REQUIRED.getMessage());
+		notNull(memberId, MEMBER_ID_REQUIRED.getMessage());
+		notNull(courseRole, COURSE_ROLE_REQUIRED.getMessage());
 
 		CourseMember courseMember = new CourseMember();
 		courseMember.course = course;
@@ -45,7 +46,7 @@ public class CourseMember extends AbstractEntity {
 	}
 
 	public void changeRole(CourseRole newRole) {
-		notNull(newRole, "[System] 새로운 역할은 필수입니다.");
+		notNull(newRole, NEW_ROLE_REQUIRED.getMessage());
 		this.courseRole = newRole;
 	}
 

--- a/src/main/java/me/chan99k/learningmanager/domain/course/CourseProblemCode.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/course/CourseProblemCode.java
@@ -1,0 +1,42 @@
+package me.chan99k.learningmanager.domain.course;
+
+import me.chan99k.learningmanager.common.exception.ProblemCode;
+
+public enum CourseProblemCode implements ProblemCode {
+	// Course related
+	COURSE_TITLE_REQUIRED("DCL001", "[System] 과정명은 필수값 입니다."),
+	COURSE_DESCRIPTION_REQUIRED("DCL002", "[System] 과정에 대한 설명 값이 비어 있습니다."),
+	COURSE_MEMBER_ALREADY_REGISTERED("DCL003", "[System] 이미 과정에 등록된 멤버입니다."),
+	COURSE_MEMBER_NOT_REGISTERED("DCL004", "[System] 과정에 등록되지 않은 멤버입니다."),
+	CURRICULUM_NULL("DCL005", "[System] 제거할 커리큘럼은 null일 수 없습니다."),
+	CURRICULUM_NOT_FOUND_IN_COURSE("DCL006", "[System] 해당 과정에 존재하지 않는 커리큘럼입니다."),
+
+	// CourseMember related
+	COURSE_REQUIRED("DCL007", "[System] 코스는 필수입니다."),
+	MEMBER_ID_REQUIRED("DCL008", "[System] 멤버 ID는 필수입니다."),
+	COURSE_ROLE_REQUIRED("DCL009", "[System] 코스 역할은 필수입니다."),
+	NEW_ROLE_REQUIRED("DCL010", "[System] 새로운 역할은 필수입니다."),
+
+	// Curriculum related
+	CURRICULUM_COURSE_REQUIRED("DCL011", "[System] 커리큘럼은 반드시 코스에 속해야 합니다."),
+	CURRICULUM_TITLE_REQUIRED("DCL012", "[System] 커리큘럼명은 필수입니다."),
+	CURRICULUM_DESCRIPTION_REQUIRED("DCL013", "[System] 커리큘럼에 대한 설명 값이 비어 있습니다.");
+
+	private final String code;
+	private final String message;
+
+	CourseProblemCode(String code, String message) {
+		this.code = code;
+		this.message = message;
+	}
+
+	@Override
+	public String getCode() {
+		return code;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/main/java/me/chan99k/learningmanager/domain/course/Curriculum.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/course/Curriculum.java
@@ -1,5 +1,6 @@
 package me.chan99k.learningmanager.domain.course;
 
+import static me.chan99k.learningmanager.domain.course.CourseProblemCode.*;
 import static org.springframework.util.Assert.*;
 
 import jakarta.persistence.Entity;
@@ -22,8 +23,8 @@ public class Curriculum extends AbstractEntity {
 	/* 도메인 로직 */
 
 	public static Curriculum create(Course course, String title, String description) {
-		notNull(course, "[System] 커리큘럼은 반드시 코스에 속해야 합니다.");
-		hasText(title, "[System] 커리큘럼명은 필수입니다.");
+		notNull(course, CURRICULUM_COURSE_REQUIRED.getMessage());
+		hasText(title, CURRICULUM_TITLE_REQUIRED.getMessage());
 
 		Curriculum curriculum = new Curriculum();
 		curriculum.course = course;
@@ -33,12 +34,12 @@ public class Curriculum extends AbstractEntity {
 	}
 
 	public void updateTitle(String newTitle) {
-		hasText(newTitle, "[System] 커리큘럼명 값이 비어 있습니다.");
+		hasText(newTitle, CURRICULUM_TITLE_REQUIRED.getMessage());
 		this.title = newTitle;
 	}
 
 	public void updateDescription(String newDescription) {
-		hasText(newDescription, "[System] 커리큘럼에 대한 설명 값이 비어 있습니다.");
+		hasText(newDescription, CURRICULUM_DESCRIPTION_REQUIRED.getMessage());
 		this.description = newDescription;
 	}
 

--- a/src/main/java/me/chan99k/learningmanager/domain/member/Account.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/member/Account.java
@@ -1,5 +1,6 @@
 package me.chan99k.learningmanager.domain.member;
 
+import static me.chan99k.learningmanager.domain.member.MemberProblemCode.*;
 import static org.springframework.util.Assert.*;
 
 import jakarta.persistence.AttributeOverride;
@@ -33,7 +34,7 @@ public class Account extends AbstractEntity {
 	/* 도메인 로직 */
 
 	public static Account create(Member member, String emailAddress, String rawPassword, PasswordEncoder encoder) {
-		notNull(member, "[System] 계정은 반드시 멤버에 속해야 합니다.");
+		notNull(member, ACCOUNT_MEMBER_REQUIRED.getMessage());
 
 		Account account = new Account();
 		account.member = member;
@@ -49,12 +50,13 @@ public class Account extends AbstractEntity {
 	}
 
 	public void activate() {
-		state(status == AccountStatus.PENDING || status == AccountStatus.INACTIVE, "[System] 활성 대기/비활성 상태의 계정이 아닙니다.");
+		state(status == AccountStatus.PENDING || status == AccountStatus.INACTIVE,
+			ACCOUNT_NOT_PENDING_OR_INACTIVE.getMessage());
 		this.status = AccountStatus.ACTIVE;
 	}
 
 	public void deactivate() {
-		state(status == AccountStatus.ACTIVE, "[System] 활성 상태의 계정이 아닙니다.");
+		state(status == AccountStatus.ACTIVE, ACCOUNT_NOT_ACTIVE.getMessage());
 		this.status = AccountStatus.INACTIVE;
 	}
 

--- a/src/main/java/me/chan99k/learningmanager/domain/member/Email.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/member/Email.java
@@ -1,5 +1,6 @@
 package me.chan99k.learningmanager.domain.member;
 
+import static me.chan99k.learningmanager.domain.member.MemberProblemCode.*;
 import static org.springframework.util.Assert.*;
 
 import java.util.regex.Pattern;
@@ -13,6 +14,6 @@ public record Email(String address) {
 	);
 
 	public Email {
-		isTrue(PATTERN.matcher(address).matches(), "유효하지 않은 이메일 형식입니다.");
+		isTrue(PATTERN.matcher(address).matches(), INVALID_EMAIL_FORMAT.getMessage());
 	}
 }

--- a/src/main/java/me/chan99k/learningmanager/domain/member/Member.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/member/Member.java
@@ -1,5 +1,6 @@
 package me.chan99k.learningmanager.domain.member;
 
+import static me.chan99k.learningmanager.domain.member.MemberProblemCode.*;
 import static org.springframework.util.Assert.*;
 
 import jakarta.persistence.AttributeOverride;
@@ -48,37 +49,37 @@ public class Member extends AbstractEntity {
 	}
 
 	public void promoteToAdmin() {
-		state(this.role == SystemRole.MEMBER, "일반 회원만 관리자로 승격될 수 있습니다.");
+		state(this.role == SystemRole.MEMBER, MEMBER_NOT_GENERAL.getMessage());
 		this.role = SystemRole.ADMIN;
 	}
 
 	public void demoteToMember() {
-		state(this.role == SystemRole.ADMIN, "관리자만 일반 회원으로 강등될 수 있습니다.");
+		state(this.role == SystemRole.ADMIN, MEMBER_NOT_ADMIN.getMessage());
 		this.role = SystemRole.MEMBER;
 	}
 
 	public void deactivate() {
-		state(this.status != MemberStatus.INACTIVE, "이미 휴면 상태의 회원입니다.");
+		state(this.status != MemberStatus.INACTIVE, MEMBER_ALREADY_INACTIVE.getMessage());
 		this.status = MemberStatus.INACTIVE;
 	}
 
 	public void activate() {
-		state(this.status == MemberStatus.INACTIVE, "휴면 상태의 회원만 활성화할 수 있습니다.");
+		state(this.status == MemberStatus.INACTIVE, MEMBER_NOT_INACTIVE.getMessage());
 		this.status = MemberStatus.ACTIVE;
 	}
 
 	public void withdraw() {
-		state(this.status != MemberStatus.WITHDRAWN, "이미 탈퇴한 회원입니다.");
+		state(this.status != MemberStatus.WITHDRAWN, MEMBER_ALREADY_WITHDRAWN.getMessage());
 		this.status = MemberStatus.WITHDRAWN;
 	}
 
 	public void ban() {
-		state(this.status == MemberStatus.ACTIVE, "활동 중인 회원만 이용 정지될 수 있습니다.");
+		state(this.status == MemberStatus.ACTIVE, MEMBER_NOT_ACTIVE.getMessage());
 		this.status = MemberStatus.BANNED;
 	}
 
 	public void unban() {
-		state(this.status == MemberStatus.BANNED, "이용 정지 상태의 회원만 해제될 수 있습니다.");
+		state(this.status == MemberStatus.BANNED, MEMBER_NOT_BANNED.getMessage());
 		this.status = MemberStatus.ACTIVE;
 	}
 

--- a/src/main/java/me/chan99k/learningmanager/domain/member/MemberProblemCode.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/member/MemberProblemCode.java
@@ -1,0 +1,45 @@
+package me.chan99k.learningmanager.domain.member;
+
+import me.chan99k.learningmanager.common.exception.ProblemCode;
+
+public enum MemberProblemCode implements ProblemCode {
+
+	MEMBER_NOT_GENERAL("DML001", "[System] 일반 회원만 관리자로 승격될 수 있습니다."),
+	MEMBER_NOT_ADMIN("DML002", "[System] 관리자만 일반 회원으로 강등될 수 있습니다."),
+	MEMBER_ALREADY_INACTIVE("DML003", "[System] 이미 휴면 상태의 회원입니다."),
+	MEMBER_NOT_INACTIVE("DML004", "[System] 휴면 상태의 회원만 활성화할 수 있습니다."),
+	MEMBER_ALREADY_WITHDRAWN("DML005", "[System] 이미 탈퇴한 회원입니다."),
+	MEMBER_NOT_ACTIVE("DML006", "[System] 활동 중인 회원만 이용 정지될 수 있습니다."),
+	MEMBER_NOT_BANNED("DML007", "[System] 이용 정지 상태의 회원만 해제될 수 있습니다."),
+
+	ACCOUNT_MEMBER_REQUIRED("DML008", "[System] 계정은 반드시 멤버에 속해야 합니다."),
+	ACCOUNT_NOT_PENDING_OR_INACTIVE("DML009", "[System] 활성 대기/비활성 상태의 계정이 아닙니다."),
+	ACCOUNT_NOT_ACTIVE("DML010", "[System] 활성 상태의 계정이 아닙니다."),
+
+	INVALID_EMAIL_FORMAT("DML011", "[System] 유효하지 않은 이메일 형식입니다."),
+
+	PASSWORD_LENGTH_INVALID("DML012", "[System] 비밀번호는 최소 8자 이상, 64자 이하여야 합니다."),
+	PASSWORD_NO_LOWERCASE("DML013", "[System] 비밀번호에는 소문자가 최소 1개 이상 포함되어야 합니다."),
+	PASSWORD_NO_UPPERCASE("DML014", "[System] 비밀번호에는 대문자가 최소 1개 이상 포함되어야 합니다."),
+	PASSWORD_NO_DIGIT("DML015", "[System] 비밀번호에는 숫자가 최소 1개 이상 포함되어야 합니다."),
+	PASSWORD_NO_SPECIAL_CHAR("DML016", "[System] 비밀번호에는 특수문자가 최소 1개 이상 포함되어야 합니다."),
+	PASSWORD_CONTAINS_WHITESPACE("DML017", "[System] 비밀번호에 공백을 포함할 수 없습니다.");
+
+	private final String code;
+	private final String message;
+
+	MemberProblemCode(String code, String message) {
+		this.code = code;
+		this.message = message;
+	}
+
+	@Override
+	public String getCode() {
+		return code;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/main/java/me/chan99k/learningmanager/domain/member/Password.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/member/Password.java
@@ -1,5 +1,6 @@
 package me.chan99k.learningmanager.domain.member;
 
+import static me.chan99k.learningmanager.domain.member.MemberProblemCode.*;
 import static org.springframework.util.Assert.*;
 
 import java.util.regex.Pattern;
@@ -28,12 +29,13 @@ public record Password(String encoded) {
 	}
 
 	private static void validatePattern(String password) {
-		state(password.length() >= MIN_LENGTH && password.length() <= MAX_LENGTH, "비밀번호는 최소 8자 이상, 64자 이하여야 합니다.");
-		state(LOWERCASE_PATTERN.matcher(password).matches(), "비밀번호에는 소문자가 최소 1개 이상 포함되어야 합니다.");
-		state(UPPERCASE_PATTERN.matcher(password).matches(), "비밀번호에는 대문자가 최소 1개 이상 포함되어야 합니다.");
-		state(DIGIT_PATTERN.matcher(password).matches(), "비밀번호에는 숫자가 최소 1개 이상 포함되어야 합니다.");
-		state(SPECIAL_CHAR_PATTERN.matcher(password).matches(), "비밀번호에는 특수문자가 최소 1개 이상 포함되어야 합니다.");
-		state(!WHITESPACE_PATTERN.matcher(password).matches(), "비밀번호에 공백을 포함할 수 없습니다.");
+		state(password.length() >= MIN_LENGTH && password.length() <= MAX_LENGTH, PASSWORD_LENGTH_INVALID.getMessage());
+		state(LOWERCASE_PATTERN.matcher(password).matches(), PASSWORD_NO_LOWERCASE.getMessage());
+		state(UPPERCASE_PATTERN.matcher(password).matches(), PASSWORD_NO_UPPERCASE.getMessage());
+		state(DIGIT_PATTERN.matcher(password).matches(), PASSWORD_NO_DIGIT.getMessage());
+		state(SPECIAL_CHAR_PATTERN.matcher(password).matches(), PASSWORD_NO_SPECIAL_CHAR.getMessage());
+		state(!WHITESPACE_PATTERN.matcher(password).matches(), PASSWORD_CONTAINS_WHITESPACE.getMessage());
 	}
 
 }
+

--- a/src/main/java/me/chan99k/learningmanager/domain/session/SessionParticipant.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/session/SessionParticipant.java
@@ -1,5 +1,6 @@
 package me.chan99k.learningmanager.domain.session;
 
+import static me.chan99k.learningmanager.domain.session.SessionProblemCode.*;
 import static org.springframework.util.Assert.*;
 
 import jakarta.persistence.Column;
@@ -34,9 +35,9 @@ public class SessionParticipant extends AbstractEntity {
 	}
 
 	public static SessionParticipant of(Long memberId, Session session, SessionParticipantRole role) {
-		notNull(session, "[System] Session 은 null 일 수 없습니다.");
-		notNull(memberId, "[System] Member ID 는 null 일 수 없습니다.");
-		notNull(role, "[System] Role 은 null 일 수 없습니다.");
+		notNull(session, SESSION_REQUIRED.getMessage());
+		notNull(memberId, MEMBER_ID_REQUIRED.getMessage());
+		notNull(role, PARTICIPANT_ROLE_REQUIRED.getMessage());
 
 		return new SessionParticipant(memberId, session, role);
 	}
@@ -50,8 +51,8 @@ public class SessionParticipant extends AbstractEntity {
 	}
 
 	public void changeRole(SessionParticipantRole newRole) {
-		notNull(newRole, "[System] 새로운 역할은 null일 수 없습니다.");
-		isTrue(this.role != newRole, "[System] 이미 해당 역할을 가지고 있습니다.");
+		notNull(newRole, PARTICIPANT_ROLE_REQUIRED.getMessage());
+		isTrue(this.role != newRole, SAME_ROLE_PARTICIPANT_ALREADY.getMessage());
 		this.role = newRole;
 	}
 }

--- a/src/main/java/me/chan99k/learningmanager/domain/session/SessionProblemCode.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/session/SessionProblemCode.java
@@ -1,0 +1,47 @@
+package me.chan99k.learningmanager.domain.session;
+
+import me.chan99k.learningmanager.common.exception.ProblemCode;
+
+public enum SessionProblemCode implements ProblemCode {
+	COURSE_ID_REQUIRED("DLS001", "[System] 코스 ID는 필수입니다."),
+	CURRICULUM_ID_REQUIRED("DLS002", "[System] 커리큘럼 ID는 필수입니다."),
+	INVALID_SESSION_HIERARCHY("DLS003", "[System] 하위 세션은 또 다른 하위 세션을 가질 수 없습니다."),
+	ALREADY_PARTICIPATING_MEMBER("DLS004", "[System] 이미 세션에 참여 중인 멤버입니다."),
+	MEMBER_NOT_PARTICIPATING("DLS005", "[System] 해당 세션에 참여하지 않는 멤버입니다."),
+	ONLY_ONE_HOST_ALLOWED("DLS006", "[System] 한 세션에는 한 명의 호스트만 지정할 수 있습니다."),
+	CANNOT_MODIFY_STARTED_SESSION("DLS007", "[System] 이미 시작된 세션은 수정할 수 없습니다."),
+	ROOT_SESSION_MODIFICATION_DEADLINE_EXCEEDED("DLS008", "[System] 루트 세션은 시작 3일 전까지만 수정할 수 있습니다."),
+	CHILD_SESSION_MODIFICATION_DEADLINE_EXCEEDED("DLS009", "[System] 하위 세션은 시작 1시간 전까지만 수정할 수 있습니다."),
+	SESSION_START_TIME_REQUIRED("DLS010", "[System] 세션 시작 시간은 필수입니다."),
+	SESSION_END_TIME_REQUIRED("DLS011", "[System] 세션 종료 시간은 필수입니다."),
+	START_TIME_MUST_BE_BEFORE_END_TIME("DLS012", "[System] 세션 시작 시간은 종료 시간보다 빨라야 합니다."),
+	SESSION_DURATION_EXCEEDS_24_HOURS("DLS013", "[System] 세션은 24시간을 초과할 수 없습니다."),
+	SESSION_CANNOT_SPAN_MULTIPLE_DAYS("DLS014", "[System] 세션은 이틀에 걸쳐 진행될 수 없습니다."),
+	OFFLINE_SESSION_LOCATION_DETAIL_REQUIRED("DLS015", "[System] 오프라인 세션은 상세 장소 설명이 필수입니다."),
+	ONLINE_SESSION_CANNOT_HAVE_LOCATION_DETAIL("DLS016", "[System] 온라인 세션은 상세 장소 설명을 가질 수 없습니다."),
+	CHILD_SESSION_MUST_HAVE_PARENT("DLS017", "[System] 하위 세션은 반드시 부모 세션을 가져야 합니다."),
+	CHILD_SESSION_START_TIME_BEFORE_PARENT("DLS018", "[System] 하위 세션의 시작 시간은 부모 세션의 시작 시간보다 빠를 수 없습니다."),
+	CHILD_SESSION_END_TIME_AFTER_PARENT("DLS019", "[System] 하위 세션의 종료 시간은 부모 세션의 종료 시간보다 늦을 수 없습니다."),
+	SAME_ROLE_PARTICIPANT_ALREADY("DLS020", "[System] 이미 해당 역할을 가지고 있습니다."),
+	SESSION_REQUIRED("DLS021", "[System] 세션 참여를 위해서는 유효한 세션이 필요합니다."),
+	MEMBER_ID_REQUIRED("DLS022", "[System] 세션 참여를 위해서는 유효한 회원 ID가 필요합니다."),
+	PARTICIPANT_ROLE_REQUIRED("DLS023", "[System] 세션 참여를 위해서는 유효한 역할이 필요합니다.");
+
+	private final String code;
+	private final String message;
+
+	SessionProblemCode(String code, String message) {
+		this.code = code;
+		this.message = message;
+	}
+
+	@Override
+	public String getCode() {
+		return code;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/test/java/me/chan99k/learningmanager/domain/attendance/AttendanceTest.java
+++ b/src/test/java/me/chan99k/learningmanager/domain/attendance/AttendanceTest.java
@@ -1,5 +1,6 @@
 package me.chan99k.learningmanager.domain.attendance;
 
+import static me.chan99k.learningmanager.domain.attendance.AttendanceProblemCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.Instant;
@@ -69,7 +70,7 @@ class AttendanceTest {
 			assertThat(attendance.getCheckOutTime()).isNotNull();
 			assertThatThrownBy(attendance::checkOut)
 				.isInstanceOf(IllegalStateException.class)
-				.hasMessage("[System] 이미 퇴실 처리된 출석 기록입니다.");
+				.hasMessage(ALREADY_CHECKED_OUT.getMessage());
 		}
 	}
 }

--- a/src/test/java/me/chan99k/learningmanager/domain/course/CourseTest.java
+++ b/src/test/java/me/chan99k/learningmanager/domain/course/CourseTest.java
@@ -1,5 +1,6 @@
 package me.chan99k.learningmanager.domain.course;
 
+import static me.chan99k.learningmanager.domain.course.CourseProblemCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
@@ -16,7 +17,7 @@ class CourseTest {
 
 	@BeforeEach
 	void setUp() {
-		course = Course.create("수정전 스터디", "JPA 기초 스터디입니다.");
+		course = Course.create("수정전 스터디", "스터디 설명");
 	}
 
 	@Nested
@@ -64,7 +65,7 @@ class CourseTest {
 
 			assertThatThrownBy(() -> course.updateTitle(null))
 				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessage("[System] 과정명 값이 비어 있습니다.");
+				.hasMessage(COURSE_TITLE_REQUIRED.getMessage());
 		}
 
 		@Test
@@ -73,7 +74,7 @@ class CourseTest {
 
 			assertThatThrownBy(() -> course.updateDescription(null))
 				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessage("[System] 과정에 대한 설명 값이 비어 있습니다.");
+				.hasMessage(COURSE_DESCRIPTION_REQUIRED.getMessage());
 		}
 
 		@Test
@@ -161,7 +162,7 @@ class CourseTest {
 			// 존재하지 않는 ID로 제거를 시도하면 예외가 발생하는 것을 검증합니다.
 			assertThatThrownBy(() -> course.removeMember(99L))
 				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessage("[System] 과정에 등록되지 않은 멤버입니다.");
+				.hasMessage(COURSE_MEMBER_NOT_REGISTERED.getMessage());
 		}
 	}
 
@@ -215,7 +216,7 @@ class CourseTest {
 
 			assertThatThrownBy(() -> course.removeCurriculum(anoutherCoursesCurriculum))
 				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessage("[System] 해당 과정에 존재하지 않는 커리큘럼입니다. ID: 99");
+				.hasMessage(CURRICULUM_NOT_FOUND_IN_COURSE.getMessage() + " ID: 99");
 		}
 
 		@Test
@@ -223,7 +224,7 @@ class CourseTest {
 		void remove_null_curriculum_fail() {
 			assertThatThrownBy(() -> course.removeCurriculum(null))
 				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessage("[System] 제거할 커리큘럼은 null일 수 없습니다.");
+				.hasMessage(CURRICULUM_NULL.getMessage());
 		}
 
 		@Test

--- a/src/test/java/me/chan99k/learningmanager/domain/course/CurriculumTest.java
+++ b/src/test/java/me/chan99k/learningmanager/domain/course/CurriculumTest.java
@@ -1,5 +1,6 @@
 package me.chan99k.learningmanager.domain.course;
 
+import static me.chan99k.learningmanager.domain.course.CourseProblemCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -62,7 +63,7 @@ class CurriculumTest {
 
 			assertThatThrownBy(() -> curriculum.updateTitle(null))
 				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessage("[System] 커리큘럼명 값이 비어 있습니다.");
+				.hasMessage(CURRICULUM_TITLE_REQUIRED.getMessage());
 		}
 
 		@Test
@@ -71,7 +72,7 @@ class CurriculumTest {
 
 			assertThatThrownBy(() -> curriculum.updateDescription(null))
 				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessage("[System] 커리큘럼에 대한 설명 값이 비어 있습니다.");
+				.hasMessage(CURRICULUM_DESCRIPTION_REQUIRED.getMessage());
 		}
 	}
 }

--- a/src/test/java/me/chan99k/learningmanager/domain/member/AccountTest.java
+++ b/src/test/java/me/chan99k/learningmanager/domain/member/AccountTest.java
@@ -1,5 +1,6 @@
 package me.chan99k.learningmanager.domain.member;
 
+import static me.chan99k.learningmanager.domain.member.MemberProblemCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.Instant;
@@ -48,7 +49,7 @@ class AccountTest {
 		void create_account_with_null_memberId_throws_exception() {
 			assertThatThrownBy(() -> Account.create(null, "test@example.com", "ValidPass123!", passwordEncoder))
 				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessage("[System] 계정은 반드시 멤버에 속해야 합니다.");
+				.hasMessage(ACCOUNT_MEMBER_REQUIRED.getMessage());
 		}
 
 	}
@@ -92,7 +93,7 @@ class AccountTest {
 
 			assertThatThrownBy(account::activate)
 				.isInstanceOf(IllegalStateException.class)
-				.hasMessage("[System] 활성 대기/비활성 상태의 계정이 아닙니다.");
+				.hasMessage(ACCOUNT_NOT_PENDING_OR_INACTIVE.getMessage());
 		}
 
 		@Test
@@ -102,7 +103,7 @@ class AccountTest {
 
 			assertThatThrownBy(account::activate)
 				.isInstanceOf(IllegalStateException.class)
-				.hasMessage("[System] 활성 대기/비활성 상태의 계정이 아닙니다.");
+				.hasMessage(ACCOUNT_NOT_PENDING_OR_INACTIVE.getMessage());
 		}
 
 		@Test
@@ -121,7 +122,7 @@ class AccountTest {
 
 			assertThatThrownBy(account::deactivate)
 				.isInstanceOf(IllegalStateException.class)
-				.hasMessage("[System] 활성 상태의 계정이 아닙니다.");
+				.hasMessage(ACCOUNT_NOT_ACTIVE.getMessage());
 		}
 	}
 

--- a/src/test/java/me/chan99k/learningmanager/domain/member/EmailTest.java
+++ b/src/test/java/me/chan99k/learningmanager/domain/member/EmailTest.java
@@ -1,12 +1,12 @@
 package me.chan99k.learningmanager.domain.member;
 
+import static me.chan99k.learningmanager.domain.member.MemberProblemCode.*;
+import static org.assertj.core.api.Assertions.*;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class EmailTest {
 
@@ -22,6 +22,6 @@ class EmailTest {
     void create_email_with_invalid_address_throws_exception(String invalidEmail) {
         assertThatThrownBy(() -> new Email(invalidEmail))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("유효하지 않은 이메일 형식입니다.");
+			.hasMessage(INVALID_EMAIL_FORMAT.getMessage());
     }
 }

--- a/src/test/java/me/chan99k/learningmanager/domain/member/MemberTest.java
+++ b/src/test/java/me/chan99k/learningmanager/domain/member/MemberTest.java
@@ -1,5 +1,6 @@
 package me.chan99k.learningmanager.domain.member;
 
+import static me.chan99k.learningmanager.domain.member.MemberProblemCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.UUID;
@@ -75,7 +76,7 @@ class MemberTest {
 
 			assertThatThrownBy(member::ban)
 				.isInstanceOf(IllegalStateException.class)
-				.hasMessage("활동 중인 회원만 이용 정지될 수 있습니다.");
+				.hasMessage(MEMBER_NOT_ACTIVE.getMessage());
 		}
 
 		@Test
@@ -83,13 +84,13 @@ class MemberTest {
 		void activate_fails_if_not_inactive() {
 			assertThatThrownBy(member::activate)
 				.isInstanceOf(IllegalStateException.class)
-				.hasMessage("휴면 상태의 회원만 활성화할 수 있습니다.");
+				.hasMessage(MEMBER_NOT_INACTIVE.getMessage());
 
 			member.ban(); // BANNED 상태로 변경
 
 			assertThatThrownBy(member::activate)
 				.isInstanceOf(IllegalStateException.class)
-				.hasMessage("휴면 상태의 회원만 활성화할 수 있습니다.");
+				.hasMessage(MEMBER_NOT_INACTIVE.getMessage());
 		}
 
 		@Test
@@ -125,7 +126,7 @@ class MemberTest {
 
 			assertThatThrownBy(member::deactivate)
 				.isInstanceOf(IllegalStateException.class)
-				.hasMessage("이미 휴면 상태의 회원입니다.");
+				.hasMessage(MEMBER_ALREADY_INACTIVE.getMessage());
 		}
 
 		@Test
@@ -135,7 +136,7 @@ class MemberTest {
 
 			assertThatThrownBy(member::withdraw)
 				.isInstanceOf(IllegalStateException.class)
-				.hasMessage("이미 탈퇴한 회원입니다.");
+				.hasMessage(MEMBER_ALREADY_WITHDRAWN.getMessage());
 		}
 
 		@Test
@@ -144,7 +145,7 @@ class MemberTest {
 			// 기본 상태(ACTIVE)에서 unban 시도
 			assertThatThrownBy(member::unban)
 				.isInstanceOf(IllegalStateException.class)
-				.hasMessage("이용 정지 상태의 회원만 해제될 수 있습니다.");
+				.hasMessage(MEMBER_NOT_BANNED.getMessage());
 		}
 	}
 
@@ -163,7 +164,8 @@ class MemberTest {
 		void fail_to_promote_admin() {
 			member.promoteToAdmin();
 			assertThat(member.getRole()).isEqualTo(SystemRole.ADMIN);
-			assertThatThrownBy(() -> member.promoteToAdmin()).isInstanceOf(IllegalStateException.class);
+			assertThatThrownBy(() -> member.promoteToAdmin()).isInstanceOf(IllegalStateException.class)
+				.hasMessage(MEMBER_NOT_GENERAL.getMessage());
 		}
 
 		@Test
@@ -179,7 +181,8 @@ class MemberTest {
 		@Test
 		@DisplayName("[Failure] 더 강등할 등급이 없는 경우, 회원 등급 강등에 실패한다..")
 		void fail_to_demote_member() {
-			assertThatThrownBy(() -> member.demoteToMember()).isInstanceOf(IllegalStateException.class);
+			assertThatThrownBy(() -> member.demoteToMember()).isInstanceOf(IllegalStateException.class)
+				.hasMessage(MEMBER_NOT_ADMIN.getMessage());
 		}
 	}
 }

--- a/src/test/java/me/chan99k/learningmanager/domain/member/PasswordTest.java
+++ b/src/test/java/me/chan99k/learningmanager/domain/member/PasswordTest.java
@@ -1,5 +1,6 @@
 package me.chan99k.learningmanager.domain.member;
 
+import static me.chan99k.learningmanager.domain.member.MemberProblemCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
@@ -55,7 +56,7 @@ class PasswordTest {
     void password_length_validation(String invalidPassword) {
         assertThatThrownBy(() -> Password.generatePassword(invalidPassword, passwordEncoder))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("비밀번호는 최소 8자 이상, 64자 이하여야 합니다.");
+            .hasMessage(PASSWORD_LENGTH_INVALID.getMessage());
     }
 
     @Test
@@ -63,7 +64,7 @@ class PasswordTest {
     void password_requires_lowercase() {
         assertThatThrownBy(() -> Password.generatePassword("VALIDPASS1!", passwordEncoder))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("비밀번호에는 소문자가 최소 1개 이상 포함되어야 합니다.");
+            .hasMessage(PASSWORD_NO_LOWERCASE.getMessage());
     }
 
     @Test
@@ -71,7 +72,7 @@ class PasswordTest {
     void password_requires_uppercase() {
         assertThatThrownBy(() -> Password.generatePassword("validpass1!", passwordEncoder))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("비밀번호에는 대문자가 최소 1개 이상 포함되어야 합니다.");
+            .hasMessage(PASSWORD_NO_UPPERCASE.getMessage());
     }
 
     @Test
@@ -79,7 +80,7 @@ class PasswordTest {
     void password_requires_digit() {
         assertThatThrownBy(() -> Password.generatePassword("ValidPass!", passwordEncoder))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("비밀번호에는 숫자가 최소 1개 이상 포함되어야 합니다.");
+            .hasMessage(PASSWORD_NO_DIGIT.getMessage());
     }
 
     @Test
@@ -87,7 +88,7 @@ class PasswordTest {
     void password_requires_special_char() {
         assertThatThrownBy(() -> Password.generatePassword("ValidPass1", passwordEncoder))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("비밀번호에는 특수문자가 최소 1개 이상 포함되어야 합니다.");
+            .hasMessage(PASSWORD_NO_SPECIAL_CHAR.getMessage());
     }
 
     @Test
@@ -95,6 +96,6 @@ class PasswordTest {
     void password_cannot_contain_whitespace() {
         assertThatThrownBy(() -> Password.generatePassword("Valid Pass 1!", passwordEncoder))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("비밀번호에 공백을 포함할 수 없습니다.");
+            .hasMessage(PASSWORD_CONTAINS_WHITESPACE.getMessage());
     }
 }


### PR DESCRIPTION
## 💡 Motivation and Context
> 이 PR은 예외 메시지를 다루는 도메인별 Enum 을 도입하여 예외 메시지의 일관성과 유지보수성을 확보합니다.

<br>

## 🔨 Modified
-	도메인 전반에 걸친 예외 메시지 일관성을 위해 common 패키지에 ProblemCode 인터페이스 정의
- AttendanceProblemCode에 출결 관련 예외 메시지 중앙화
-	CourseProblemCode에 강의 관련 예외 메시지 중앙화
-	MemberProblemCode에 멤버 관련 예외 메시지 중앙화
-	SessionProblemCode에 세션 관련 예외 메시지 중앙화


<br>

## 🌟 More

<br>

---


### 📋 체크리스트
- [ ] 추가/변경에 대한 테스트
- [ ] 코드 컨벤션

<br>

### 🤟🏻 PR로 완료된 이슈
> closes #