### PR TITLE
스프링 시큐리티 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,13 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/me/chan99k/learningmanager/adapter/auth/BcryptPasswordEncoder.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/auth/BcryptPasswordEncoder.java
@@ -1,0 +1,28 @@
+package me.chan99k.learningmanager.adapter.auth;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import me.chan99k.learningmanager.domain.member.PasswordEncoder;
+
+@Component
+@Primary
+public class BcryptPasswordEncoder implements PasswordEncoder {
+
+	private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+	public BcryptPasswordEncoder() {
+		this.bCryptPasswordEncoder = new BCryptPasswordEncoder();
+	}
+
+	@Override
+	public String encode(String rawString) {
+		return bCryptPasswordEncoder.encode(rawString);
+	}
+
+	@Override
+	public boolean match(String rawString, String encoded) {
+		return bCryptPasswordEncoder.matches(rawString, encoded);
+	}
+}

--- a/src/main/java/me/chan99k/learningmanager/adapter/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,68 @@
+package me.chan99k.learningmanager.adapter.auth;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+@Profile("!test")
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+	private static final Logger log = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
+	private static final String BEARER_PREFIX = "Bearer ";
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+		this.jwtTokenProvider = jwtTokenProvider;
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain
+	) throws ServletException, IOException {
+		String token = resolveToken(request);
+		log.info("===== JWT FILTER DEBUG START =====");
+		log.info("Request URI : {}", request.getRequestURI());
+		log.info("Token: :{}", token);
+
+		if (token != null && jwtTokenProvider.validateToken(token)) {
+			String memberId = jwtTokenProvider.getMemberIdFromToken(token);
+			log.info("Member ID from token: {}", memberId);
+			// TODO: 실제로는 Member 엔티티에서 권한 정보를 조회해야 함
+			var authorities = Collections.singletonList(new SimpleGrantedAuthority("MEMBER"));
+			// TODO: 실제로는 Password VO 가 필요함!!
+			var authentication = new UsernamePasswordAuthenticationToken(
+				memberId, null, authorities
+			);
+
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+			log.info("[System] Authentication set 을 SecurityContext 에 캐시 하였습니다.");
+		} else {
+			log.debug("[System] 토큰 검증이 실패하였거나 토큰의 값이 null 입니다");
+		}
+		log.info("===== JWT FILTER DEBUG ENDS =====");
+		filterChain.doFilter(request, response);
+	}
+
+	private String resolveToken(HttpServletRequest request) {
+		var bearer = request.getHeader("Authorization");
+		if (StringUtils.hasText(bearer) && bearer.startsWith(BEARER_PREFIX)) {
+			return bearer.substring(BEARER_PREFIX.length());
+		}
+		return null; // FIXME :: null 반환은 지양하도록 변경하기
+	}
+}

--- a/src/main/java/me/chan99k/learningmanager/adapter/auth/JwtTokenProvider.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/auth/JwtTokenProvider.java
@@ -1,0 +1,66 @@
+package me.chan99k.learningmanager.adapter.auth;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+@Profile("!test")
+public class JwtTokenProvider {
+	private final SecretKey secretKey;
+	private final long tokenValidityInMilliseconds;
+
+	public JwtTokenProvider(
+		@Value("${jwt.secret:learning-manager-jwt-secret-key-for-development}")
+		String secretKey,
+		@Value("${jwt.token-validity-in-seconds:86400}")
+		long tokenValidityInSeconds
+	) {
+		this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes());
+		this.tokenValidityInMilliseconds = tokenValidityInSeconds * 1000;
+	}
+
+	public String createToken(Long memberId) {
+		Instant now = Instant.now();
+		Instant expires = now.plus(tokenValidityInMilliseconds, ChronoUnit.MILLIS);
+
+		return Jwts.builder()
+			.subject(String.valueOf(memberId))
+			.issuedAt(Date.from(now))
+			.expiration(Date.from(expires))
+			.signWith(secretKey)
+			.compact();
+	}
+
+	public boolean validateToken(String token) {
+		try {
+			Jwts.parser()
+				.verifyWith(secretKey)
+				.build()
+				.parseSignedClaims(token);
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	public String getMemberIdFromToken(String token) {
+		Claims payload = Jwts.parser()
+			.verifyWith(secretKey)
+			.build()
+			.parseSignedClaims(token)
+			.getPayload();
+
+		return payload.getSubject();
+	}
+}

--- a/src/main/java/me/chan99k/learningmanager/common/config/SecurityConfig.java
+++ b/src/main/java/me/chan99k/learningmanager/common/config/SecurityConfig.java
@@ -1,0 +1,74 @@
+package me.chan99k.learningmanager.common.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import me.chan99k.learningmanager.adapter.auth.JwtAuthenticationFilter;
+
+@Configuration
+@Profile("!test")
+public class SecurityConfig {
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+	public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+		this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+	}
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+
+		httpSecurity
+			.csrf(AbstractHttpConfigurer::disable)
+			.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class) // JWT 필터 추가
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers(HttpMethod.POST, "api/v1/members/register").permitAll()
+				.requestMatchers(HttpMethod.POST, "api/v1/members/auth/token").permitAll()
+				.requestMatchers(HttpMethod.POST, "api/v1/members/activate").authenticated()
+				.requestMatchers(HttpMethod.GET, "/api/v1/members/*/profile-public").permitAll()
+				.requestMatchers("/h2-console/**").permitAll()
+				.anyRequest().authenticated()
+			)
+			.exceptionHandling(ex -> ex
+				.authenticationEntryPoint((request, response, authException) -> {
+					response.setStatus(HttpStatus.UNAUTHORIZED.value());
+					response.setContentType("application/problem+json");
+					response.getWriter()
+						.write(
+							"{\"type\":\"https://api.lm.com/errors/authentication\",\"title\":\"Unauthorized\",\"status\":401,\"detail\":\"[System] 사용자 인증이 필요합니다\",\"code\":\"UNAUTHORIZED\"}");
+				})
+				.accessDeniedHandler((request, response, accessDeniedException) -> {
+					response.setStatus(HttpStatus.FORBIDDEN.value());
+					response.setContentType("application/problem+json");
+					response.getWriter()
+						.write(
+							"{\"type\":\"https://api.lm.com/errors/authorization\",\"title\":\"Forbidden\",\"status\":403,\"detail\":\"[System] 접근 권한이 없습니다\",\"code\":\"FORBIDDEN\"}");
+				})
+			)
+			.headers(h -> h.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
+			.cors(Customizer.withDefaults());
+
+		return httpSecurity.build();
+	}
+
+	@Bean
+	public DelegatingSecurityContextAsyncTaskExecutor securityContextAsyncTaskExecutor(
+		@Qualifier("memberTaskExecutor") AsyncTaskExecutor memberTaskExecutor
+	) {
+		return new DelegatingSecurityContextAsyncTaskExecutor(memberTaskExecutor);
+	}
+
+}

--- a/src/test/java/me/chan99k/learningmanager/adapter/web/MemberRegisterControllerTest.java
+++ b/src/test/java/me/chan99k/learningmanager/adapter/web/MemberRegisterControllerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -27,7 +28,8 @@ import me.chan99k.learningmanager.application.member.MemberRegisterService;
 import me.chan99k.learningmanager.application.member.provides.MemberRegistration;
 import me.chan99k.learningmanager.application.member.provides.SignUpConfirmation;
 
-@WebMvcTest(MemberRegisterController.class)
+@WebMvcTest(value = MemberRegisterController.class)
+@AutoConfigureMockMvc(addFilters = false)
 public class MemberRegisterControllerTest {
 
 	private static final String TEST_EMAIL = "test@example.com";

--- a/src/test/java/me/chan99k/learningmanager/common/config/TestSecurityConfig.java
+++ b/src/test/java/me/chan99k/learningmanager/common/config/TestSecurityConfig.java
@@ -1,0 +1,38 @@
+package me.chan99k.learningmanager.common.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@Profile("test")
+public class TestSecurityConfig {
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+		httpSecurity
+			.csrf(AbstractHttpConfigurer::disable)
+			.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(auth -> auth
+				.anyRequest().permitAll() // 테스트에서는 모든 요청 허용
+			)
+			.headers(h -> h.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable));
+
+		return httpSecurity.build();
+	}
+
+	@Bean
+	public DelegatingSecurityContextAsyncTaskExecutor securityContextAsyncTaskExecutor(
+		@Qualifier("memberTaskExecutor") AsyncTaskExecutor memberTaskExecutor
+	) {
+		return new DelegatingSecurityContextAsyncTaskExecutor(memberTaskExecutor);
+	}
+}


### PR DESCRIPTION
## 💡 Motivation and Context
> 이 PR은 Spring Security를 통해 인증 및 보안을 강화하고, 테스트 환경에서 더 수월한 테스트를 지원하기 위해 MockMvc 설정을 추가합니다.

<br>

## 🔨 Modified
> 여기에 무엇이 바뀌었는지 설명해 주세요
  - JwtAuthenticationFilter를 통한 JWT 토큰 인증 처리 로직 구현
  - Spring Security 설정 추가
  - Jwt 토큰 생성 및 검증 로직 구현
  - 비밀번호 암호화를 위한 BcryptPasswordEncoder 추가
  - MemberRegisterControllerTest 클래스에 @AutoConfigureMockMvc 어노테이션 추가
  - 테스트 환경에서 필터 비활성화를 위한 MockMvc 설정 변경
  - build.gradle에 Spring Security 관련 의존성 추가

<br>

## 🌟 More
> _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_
- JWT 토큰 만료 처리 로직 추가
- 사용자 권한 관리 추가

<br>

---


### 📋 체크리스트
- [x] 추가/변경에 대한 테스트
- [x] 코드 컨벤션

<br>

### 🤟🏻 PR로 완료된 이슈
> closes #