### PR TITLE
회원 상태 변경 및 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/me/chan99k/learningmanager/adapter/persistence/course/CourseQueryAdapter.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/persistence/course/CourseQueryAdapter.java
@@ -1,5 +1,6 @@
 package me.chan99k.learningmanager.adapter.persistence.course;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
@@ -29,5 +30,10 @@ public class CourseQueryAdapter implements CourseQueryRepository {
 	@Override
 	public Optional<Course> findManagedCourseById(Long courseId, Long memberId) {
 		return jpaCourseRepository.findManagedCourseById(courseId, memberId);
+	}
+
+	@Override
+	public List<Course> findManagedCoursesByMemberId(Long memberId) {
+		return jpaCourseRepository.findManagedCoursesByMemberId(memberId);
 	}
 }

--- a/src/main/java/me/chan99k/learningmanager/adapter/persistence/course/CourseQueryAdapter.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/persistence/course/CourseQueryAdapter.java
@@ -9,8 +9,7 @@ import me.chan99k.learningmanager.application.course.requires.CourseQueryReposit
 import me.chan99k.learningmanager.domain.course.Course;
 
 @Repository
-public class CourseQueryAdapter
-	implements CourseQueryRepository, me.chan99k.learningmanager.application.member.requires.CourseQueryRepository {
+public class CourseQueryAdapter implements CourseQueryRepository {
 
 	private final JpaCourseRepository jpaCourseRepository;
 

--- a/src/main/java/me/chan99k/learningmanager/adapter/persistence/course/CourseQueryAdapter.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/persistence/course/CourseQueryAdapter.java
@@ -9,7 +9,8 @@ import me.chan99k.learningmanager.application.course.requires.CourseQueryReposit
 import me.chan99k.learningmanager.domain.course.Course;
 
 @Repository
-public class CourseQueryAdapter implements CourseQueryRepository {
+public class CourseQueryAdapter
+	implements CourseQueryRepository, me.chan99k.learningmanager.application.member.requires.CourseQueryRepository {
 
 	private final JpaCourseRepository jpaCourseRepository;
 

--- a/src/main/java/me/chan99k/learningmanager/adapter/persistence/course/JpaCourseRepository.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/persistence/course/JpaCourseRepository.java
@@ -1,5 +1,6 @@
 package me.chan99k.learningmanager.adapter.persistence.course;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,4 +16,8 @@ public interface JpaCourseRepository extends JpaRepository<Course, Long> {
 		"WHERE c.id = :courseId AND cm.memberId = :memberId AND cm.courseRole = 'MANAGER'")
 	Optional<Course> findManagedCourseById(@Param("courseId") Long courseId,
 		@Param("memberId") Long memberId);
+
+	@Query("SELECT c FROM Course c JOIN c.courseMemberList cm " +
+		"WHERE cm.memberId = :memberId AND cm.courseRole = 'MANAGER'")
+	List<Course> findManagedCoursesByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/me/chan99k/learningmanager/adapter/persistence/course/MemberCourseQueryAdapter.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/persistence/course/MemberCourseQueryAdapter.java
@@ -1,0 +1,23 @@
+package me.chan99k.learningmanager.adapter.persistence.course;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import me.chan99k.learningmanager.application.member.requires.CourseQueryRepository;
+import me.chan99k.learningmanager.domain.course.Course;
+
+@Repository
+public class MemberCourseQueryAdapter implements CourseQueryRepository {
+
+	private final JpaCourseRepository jpaCourseRepository;
+
+	public MemberCourseQueryAdapter(JpaCourseRepository jpaCourseRepository) {
+		this.jpaCourseRepository = jpaCourseRepository;
+	}
+
+	@Override
+	public List<Course> findManagedCoursesByMemberId(Long memberId) {
+		return jpaCourseRepository.findManagedCoursesByMemberId(memberId);
+	}
+}

--- a/src/main/java/me/chan99k/learningmanager/adapter/web/member/MemberAdminController.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/web/member/MemberAdminController.java
@@ -1,0 +1,43 @@
+package me.chan99k.learningmanager.adapter.web.member;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import me.chan99k.learningmanager.application.member.provides.MemberStatusChange;
+import me.chan99k.learningmanager.domain.member.MemberStatus;
+
+@RestController
+@RequestMapping("/api/v1/admin/members")
+public class MemberAdminController {
+
+	private final MemberStatusChange memberStatusChangeService;
+
+	public MemberAdminController(MemberStatusChange memberStatusChangeService) {
+		this.memberStatusChangeService = memberStatusChangeService;
+	}
+
+	@PutMapping("/{memberId}/status")
+	public ResponseEntity<Void> changeStatus(
+		@PathVariable Long memberId,
+		@Valid @RequestBody ChangeStatusRequest request
+	) {
+		MemberStatusChange.Request serviceRequest = new MemberStatusChange.Request(
+			memberId,
+			request.status()
+		);
+
+		memberStatusChangeService.changeStatus(serviceRequest);
+
+		return ResponseEntity.noContent().build();
+	}
+
+	public record ChangeStatusRequest(
+		MemberStatus status
+	) {
+	}
+}

--- a/src/main/java/me/chan99k/learningmanager/adapter/web/member/MemberProfileController.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/web/member/MemberProfileController.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +18,7 @@ import me.chan99k.learningmanager.adapter.auth.AuthProblemCode;
 import me.chan99k.learningmanager.adapter.auth.AuthenticationContextHolder;
 import me.chan99k.learningmanager.application.member.provides.MemberProfileRetrieval;
 import me.chan99k.learningmanager.application.member.provides.MemberProfileUpdate;
+import me.chan99k.learningmanager.application.member.provides.MemberWithdrawal;
 import me.chan99k.learningmanager.common.exception.AuthenticationException;
 
 @RestController
@@ -26,12 +28,15 @@ public class MemberProfileController {
 
 	private final MemberProfileUpdate memberProfileUpdate;
 	private final MemberProfileRetrieval memberProfileRetrieval;
+	private final MemberWithdrawal memberWithdrawal;
 	private final AsyncTaskExecutor memberTaskExecutor;
 
 	public MemberProfileController(MemberProfileUpdate memberProfileUpdate,
-		MemberProfileRetrieval memberProfileRetrieval, AsyncTaskExecutor memberTaskExecutor) {
+		MemberProfileRetrieval memberProfileRetrieval, MemberWithdrawal memberWithdrawal,
+		AsyncTaskExecutor memberTaskExecutor) {
 		this.memberProfileUpdate = memberProfileUpdate;
 		this.memberProfileRetrieval = memberProfileRetrieval;
+		this.memberWithdrawal = memberWithdrawal;
 		this.memberTaskExecutor = memberTaskExecutor;
 	}
 
@@ -65,6 +70,12 @@ public class MemberProfileController {
 			MemberProfileRetrieval.Response publicProfile = memberProfileRetrieval.getPublicProfile(nickname);
 			return ResponseEntity.ok(publicProfile);
 		}, memberTaskExecutor);
+	}
+
+	@DeleteMapping("/withdrawal")
+	public ResponseEntity<Void> withdrawal() {
+		memberWithdrawal.withdrawal();
+		return ResponseEntity.noContent().build();
 	}
 
 	private Long extractMemberIdFromAuthentication() {

--- a/src/main/java/me/chan99k/learningmanager/application/course/requires/CourseQueryRepository.java
+++ b/src/main/java/me/chan99k/learningmanager/application/course/requires/CourseQueryRepository.java
@@ -1,5 +1,6 @@
 package me.chan99k.learningmanager.application.course.requires;
 
+import java.util.List;
 import java.util.Optional;
 
 import me.chan99k.learningmanager.domain.course.Course;
@@ -10,5 +11,7 @@ public interface CourseQueryRepository {
 	Optional<Course> findByTitle(String title);
 
 	Optional<Course> findManagedCourseById(Long courseId, Long memberId);
+
+	List<Course> findManagedCoursesByMemberId(Long memberId);
 
 }

--- a/src/main/java/me/chan99k/learningmanager/application/member/MemberStatusChangeService.java
+++ b/src/main/java/me/chan99k/learningmanager/application/member/MemberStatusChangeService.java
@@ -51,7 +51,7 @@ public class MemberStatusChangeService implements MemberStatusChange {
 			case INACTIVE -> targetMember.deactivate();
 			case BANNED -> targetMember.ban();
 			case WITHDRAWN -> targetMember.withdraw();
-			default -> throw new IllegalArgumentException("지원하지 않는 상태 변경입니다: " + newStatus);
+			default -> throw new AssertionError("Unreachable code: 지원하지 않는 상태 변경입니다: " + newStatus);
 		}
 
 		memberCommandRepository.save(targetMember);

--- a/src/main/java/me/chan99k/learningmanager/application/member/MemberStatusChangeService.java
+++ b/src/main/java/me/chan99k/learningmanager/application/member/MemberStatusChangeService.java
@@ -1,0 +1,59 @@
+package me.chan99k.learningmanager.application.member;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import me.chan99k.learningmanager.adapter.auth.AuthProblemCode;
+import me.chan99k.learningmanager.adapter.auth.AuthenticationContextHolder;
+import me.chan99k.learningmanager.application.member.provides.MemberStatusChange;
+import me.chan99k.learningmanager.application.member.requires.MemberCommandRepository;
+import me.chan99k.learningmanager.application.member.requires.MemberQueryRepository;
+import me.chan99k.learningmanager.common.exception.AuthenticationException;
+import me.chan99k.learningmanager.common.exception.AuthorizationException;
+import me.chan99k.learningmanager.common.exception.DomainException;
+import me.chan99k.learningmanager.domain.member.Member;
+import me.chan99k.learningmanager.domain.member.MemberProblemCode;
+import me.chan99k.learningmanager.domain.member.MemberStatus;
+import me.chan99k.learningmanager.domain.member.SystemRole;
+
+@Service
+@Transactional
+public class MemberStatusChangeService implements MemberStatusChange {
+
+	private final MemberQueryRepository memberQueryRepository;
+	private final MemberCommandRepository memberCommandRepository;
+
+	public MemberStatusChangeService(
+		MemberQueryRepository memberQueryRepository,
+		MemberCommandRepository memberCommandRepository) {
+		this.memberQueryRepository = memberQueryRepository;
+		this.memberCommandRepository = memberCommandRepository;
+	}
+
+	@Override
+	public void changeStatus(Request request) {
+		Long currentMemberId = AuthenticationContextHolder.getCurrentMemberId()
+			.orElseThrow(() -> new AuthenticationException(AuthProblemCode.AUTHENTICATION_CONTEXT_NOT_FOUND));
+
+		Member currentMember = memberQueryRepository.findById(currentMemberId)
+			.orElseThrow(() -> new DomainException(MemberProblemCode.MEMBER_NOT_FOUND));
+
+		if (currentMember.getRole() != SystemRole.ADMIN) {
+			throw new AuthorizationException(AuthProblemCode.AUTHORIZATION_REQUIRED);
+		}
+
+		Member targetMember = memberQueryRepository.findById(request.memberId())
+			.orElseThrow(() -> new DomainException(MemberProblemCode.MEMBER_NOT_FOUND));
+
+		MemberStatus newStatus = request.status();
+		switch (newStatus) {
+			case ACTIVE -> targetMember.activate();
+			case INACTIVE -> targetMember.deactivate();
+			case BANNED -> targetMember.ban();
+			case WITHDRAWN -> targetMember.withdraw();
+			default -> throw new IllegalArgumentException("지원하지 않는 상태 변경입니다: " + newStatus);
+		}
+
+		memberCommandRepository.save(targetMember);
+	}
+}

--- a/src/main/java/me/chan99k/learningmanager/application/member/MemberWithdrawalService.java
+++ b/src/main/java/me/chan99k/learningmanager/application/member/MemberWithdrawalService.java
@@ -47,7 +47,7 @@ public class MemberWithdrawalService implements MemberWithdrawal {
 			memberId); // 관리 권한을 가진 채로 탈퇴 불가
 
 		if (!managedCourses.isEmpty()) {
-			throw new IllegalStateException("스터디장 권한을 다른 멤버에게 위임한 후 탈퇴할 수 있습니다.");
+			throw new IllegalStateException(MemberProblemCode.CANNOT_WITHDRAW_WHEN_YOU_ARE_MANAGER.getMessage());
 		}
 
 		member.withdraw();

--- a/src/main/java/me/chan99k/learningmanager/application/member/MemberWithdrawalService.java
+++ b/src/main/java/me/chan99k/learningmanager/application/member/MemberWithdrawalService.java
@@ -1,0 +1,61 @@
+package me.chan99k.learningmanager.application.member;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import me.chan99k.learningmanager.adapter.auth.AuthProblemCode;
+import me.chan99k.learningmanager.adapter.auth.AuthenticationContextHolder;
+import me.chan99k.learningmanager.application.course.requires.CourseQueryRepository;
+import me.chan99k.learningmanager.application.member.provides.MemberWithdrawal;
+import me.chan99k.learningmanager.application.member.requires.MemberCommandRepository;
+import me.chan99k.learningmanager.application.member.requires.MemberQueryRepository;
+import me.chan99k.learningmanager.common.exception.AuthenticationException;
+import me.chan99k.learningmanager.common.exception.DomainException;
+import me.chan99k.learningmanager.domain.course.Course;
+import me.chan99k.learningmanager.domain.member.Account;
+import me.chan99k.learningmanager.domain.member.Member;
+import me.chan99k.learningmanager.domain.member.MemberProblemCode;
+
+@Service
+@Transactional
+public class MemberWithdrawalService implements MemberWithdrawal {
+
+	private final MemberQueryRepository memberQueryRepository;
+	private final MemberCommandRepository memberCommandRepository;
+	private final CourseQueryRepository courseQueryRepository;
+
+	public MemberWithdrawalService(
+		MemberQueryRepository memberQueryRepository,
+		MemberCommandRepository memberCommandRepository,
+		CourseQueryRepository courseQueryRepository) {
+		this.memberQueryRepository = memberQueryRepository;
+		this.memberCommandRepository = memberCommandRepository;
+		this.courseQueryRepository = courseQueryRepository;
+	}
+
+	@Override
+	public void withdrawal() {
+		Long memberId = AuthenticationContextHolder.getCurrentMemberId()
+			.orElseThrow(() -> new AuthenticationException(AuthProblemCode.AUTHENTICATION_CONTEXT_NOT_FOUND));
+
+		Member member = memberQueryRepository.findById(memberId)
+			.orElseThrow(() -> new DomainException(MemberProblemCode.MEMBER_NOT_FOUND));
+
+		List<Course> managedCourses = courseQueryRepository.findManagedCoursesByMemberId(
+			memberId); // 관리 권한을 가진 채로 탈퇴 불가
+
+		if (!managedCourses.isEmpty()) {
+			throw new IllegalStateException("스터디장 권한을 다른 멤버에게 위임한 후 탈퇴할 수 있습니다.");
+		}
+
+		member.withdraw();
+
+		for (Account account : member.getAccounts()) {
+			member.deactivateAccount(account.getId());
+		}
+
+		memberCommandRepository.save(member);
+	}
+}

--- a/src/main/java/me/chan99k/learningmanager/application/member/MemberWithdrawalService.java
+++ b/src/main/java/me/chan99k/learningmanager/application/member/MemberWithdrawalService.java
@@ -7,8 +7,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import me.chan99k.learningmanager.adapter.auth.AuthProblemCode;
 import me.chan99k.learningmanager.adapter.auth.AuthenticationContextHolder;
-import me.chan99k.learningmanager.application.course.requires.CourseQueryRepository;
 import me.chan99k.learningmanager.application.member.provides.MemberWithdrawal;
+import me.chan99k.learningmanager.application.member.requires.CourseQueryRepository;
 import me.chan99k.learningmanager.application.member.requires.MemberCommandRepository;
 import me.chan99k.learningmanager.application.member.requires.MemberQueryRepository;
 import me.chan99k.learningmanager.common.exception.AuthenticationException;

--- a/src/main/java/me/chan99k/learningmanager/application/member/provides/MemberStatusChange.java
+++ b/src/main/java/me/chan99k/learningmanager/application/member/provides/MemberStatusChange.java
@@ -1,8 +1,14 @@
 package me.chan99k.learningmanager.application.member.provides;
 
-/**
- * [P2] 회원 상태 변경
- */
+import me.chan99k.learningmanager.domain.member.MemberStatus;
+
 public interface MemberStatusChange {
-	void promote();
+
+	void changeStatus(Request request);
+
+	record Request(
+		Long memberId,
+		MemberStatus status
+	) {
+	}
 }

--- a/src/main/java/me/chan99k/learningmanager/application/member/provides/MemberWithdrawal.java
+++ b/src/main/java/me/chan99k/learningmanager/application/member/provides/MemberWithdrawal.java
@@ -1,8 +1,5 @@
 package me.chan99k.learningmanager.application.member.provides;
 
-/**
- * [P2] 회원 탈퇴
- */
 public interface MemberWithdrawal {
 	void withdrawal();
 }

--- a/src/main/java/me/chan99k/learningmanager/application/member/requires/CourseQueryRepository.java
+++ b/src/main/java/me/chan99k/learningmanager/application/member/requires/CourseQueryRepository.java
@@ -1,0 +1,11 @@
+package me.chan99k.learningmanager.application.member.requires;
+
+import java.util.List;
+
+import me.chan99k.learningmanager.domain.course.Course;
+
+public interface CourseQueryRepository {
+
+	List<Course> findManagedCoursesByMemberId(Long memberId);
+
+}

--- a/src/main/java/me/chan99k/learningmanager/domain/member/MemberProblemCode.java
+++ b/src/main/java/me/chan99k/learningmanager/domain/member/MemberProblemCode.java
@@ -43,7 +43,8 @@ public enum MemberProblemCode implements ProblemCode {
 	MEMBER_REGISTRATION_FAILED("DML023", "[System] 회원 등록에 실패했습니다."),
 
 	INVALID_ACTIVATION_TOKEN("DML024", "[System] 유효하지 않은 회원 활성화 토큰입니다."),
-	EXPIRED_ACTIVATION_TOKEN("DML025", "[System] 회원 활성화 토큰이 만료되었습니다.");
+	EXPIRED_ACTIVATION_TOKEN("DML025", "[System] 회원 활성화 토큰이 만료되었습니다."),
+	CANNOT_WITHDRAW_WHEN_YOU_ARE_MANAGER("DML026", "[System] 스터디장 권한을 다른 멤버에게 위임한 후 탈퇴할 수 있습니다.");
 
 	private final String code;
 	private final String message;

--- a/src/test/java/me/chan99k/learningmanager/adapter/web/member/MemberAdminControllerTest.java
+++ b/src/test/java/me/chan99k/learningmanager/adapter/web/member/MemberAdminControllerTest.java
@@ -1,0 +1,81 @@
+package me.chan99k.learningmanager.adapter.web.member;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import me.chan99k.learningmanager.adapter.auth.BcryptPasswordEncoder;
+import me.chan99k.learningmanager.adapter.auth.JwtCredentialProvider;
+import me.chan99k.learningmanager.adapter.auth.jwt.AccessJwtTokenProvider;
+import me.chan99k.learningmanager.adapter.auth.jwt.InMemoryJwtTokenRevocationProvider;
+import me.chan99k.learningmanager.application.member.provides.MemberStatusChange;
+import me.chan99k.learningmanager.domain.member.MemberStatus;
+
+@WebMvcTest(MemberAdminController.class)
+@Import({
+	JwtCredentialProvider.class,
+	AccessJwtTokenProvider.class,
+	InMemoryJwtTokenRevocationProvider.class,
+	BcryptPasswordEncoder.class
+})
+class MemberAdminControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private MemberStatusChange memberStatusChange;
+
+	@Test
+	@DisplayName("[Success] 관리자가 회원 상태 변경 요청이 성공하면 204 No Content를 반환한다")
+	void changeStatus_Success() throws Exception {
+		Long memberId = 1L;
+		MemberAdminController.ChangeStatusRequest request =
+			new MemberAdminController.ChangeStatusRequest(MemberStatus.BANNED);
+
+		doNothing().when(memberStatusChange).changeStatus(any(MemberStatusChange.Request.class));
+
+		mockMvc.perform(put("/api/v1/admin/members/{memberId}/status", memberId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andDo(print())
+			.andExpect(status().isNoContent());
+
+		verify(memberStatusChange).changeStatus(argThat(req ->
+			req.memberId().equals(memberId) &&
+				req.status().equals(MemberStatus.BANNED)));
+	}
+
+	@Test
+	@DisplayName("[Success] 회원 상태를 ACTIVE로 변경 요청이 성공한다")
+	void changeStatus_Success_Activate() throws Exception {
+		Long memberId = 2L;
+		MemberAdminController.ChangeStatusRequest request =
+			new MemberAdminController.ChangeStatusRequest(MemberStatus.ACTIVE);
+
+		doNothing().when(memberStatusChange).changeStatus(any(MemberStatusChange.Request.class));
+
+		mockMvc.perform(put("/api/v1/admin/members/{memberId}/status", memberId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andDo(print())
+			.andExpect(status().isNoContent());
+
+		verify(memberStatusChange).changeStatus(any(MemberStatusChange.Request.class));
+	}
+}

--- a/src/test/java/me/chan99k/learningmanager/adapter/web/member/MemberProfileControllerTest.java
+++ b/src/test/java/me/chan99k/learningmanager/adapter/web/member/MemberProfileControllerTest.java
@@ -26,6 +26,7 @@ import me.chan99k.learningmanager.adapter.auth.AuthenticationContextHolder;
 import me.chan99k.learningmanager.adapter.web.GlobalExceptionHandler;
 import me.chan99k.learningmanager.application.member.provides.MemberProfileRetrieval;
 import me.chan99k.learningmanager.application.member.provides.MemberProfileUpdate;
+import me.chan99k.learningmanager.application.member.provides.MemberWithdrawal;
 import me.chan99k.learningmanager.common.exception.DomainException;
 
 @WebMvcTest(controllers = MemberProfileController.class)
@@ -40,6 +41,9 @@ class MemberProfileControllerTest {
 
 	@MockBean
 	MemberProfileRetrieval memberProfileRetrieval;
+
+	@MockBean
+	MemberWithdrawal memberWithdrawal;
 
 	@MockBean
 	AccessTokenProvider<Long> accessTokenProvider;
@@ -173,6 +177,17 @@ class MemberProfileControllerTest {
 			"img".equals(req.profileImageUrl()) &&
 				"intro".equals(req.selfIntroduction())
 		));
+	}
+
+	@Test
+	@DisplayName("[Success] 회원 탈퇴 요청이 성공하면 204 No Content를 반환한다")
+	void withdrawal_Success() throws Exception {
+		doNothing().when(memberWithdrawal).withdrawal();
+
+		mockMvc.perform(delete("/api/v1/members/withdrawal"))
+			.andExpect(status().isNoContent());
+
+		verify(memberWithdrawal).withdrawal();
 	}
 
 	private void setAuthenticatedUser(Long memberId) {

--- a/src/test/java/me/chan99k/learningmanager/application/member/MemberStatusChangeServiceTest.java
+++ b/src/test/java/me/chan99k/learningmanager/application/member/MemberStatusChangeServiceTest.java
@@ -1,0 +1,148 @@
+package me.chan99k.learningmanager.application.member;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import me.chan99k.learningmanager.adapter.auth.AuthProblemCode;
+import me.chan99k.learningmanager.adapter.auth.AuthenticationContextHolder;
+import me.chan99k.learningmanager.application.member.provides.MemberStatusChange;
+import me.chan99k.learningmanager.application.member.requires.MemberCommandRepository;
+import me.chan99k.learningmanager.application.member.requires.MemberQueryRepository;
+import me.chan99k.learningmanager.common.exception.AuthenticationException;
+import me.chan99k.learningmanager.common.exception.AuthorizationException;
+import me.chan99k.learningmanager.common.exception.DomainException;
+import me.chan99k.learningmanager.domain.member.Member;
+import me.chan99k.learningmanager.domain.member.MemberProblemCode;
+import me.chan99k.learningmanager.domain.member.MemberStatus;
+import me.chan99k.learningmanager.domain.member.SystemRole;
+
+@ExtendWith(MockitoExtension.class)
+class MemberStatusChangeServiceTest {
+
+	@InjectMocks
+	private MemberStatusChangeService memberStatusChangeService;
+
+	@Mock
+	private MemberQueryRepository memberQueryRepository;
+
+	@Mock
+	private MemberCommandRepository memberCommandRepository;
+
+	@Mock
+	private Member adminMember;
+
+	@Mock
+	private Member targetMember;
+
+	@Test
+	@DisplayName("[Success] 관리자가 회원 상태를 BANNED로 변경에 성공한다")
+	void changeStatus_Success_BanMember() {
+		Long adminId = 1L;
+		Long targetMemberId = 2L;
+
+		try (MockedStatic<AuthenticationContextHolder> mockedContext = mockStatic(AuthenticationContextHolder.class)) {
+			mockedContext.when(AuthenticationContextHolder::getCurrentMemberId).thenReturn(Optional.of(adminId));
+			when(memberQueryRepository.findById(adminId)).thenReturn(Optional.of(adminMember));
+			when(memberQueryRepository.findById(targetMemberId)).thenReturn(Optional.of(targetMember));
+			when(adminMember.getRole()).thenReturn(SystemRole.ADMIN);
+
+			MemberStatusChange.Request request = new MemberStatusChange.Request(targetMemberId, MemberStatus.BANNED);
+
+			memberStatusChangeService.changeStatus(request);
+
+			verify(targetMember).ban();
+			verify(memberCommandRepository).save(targetMember);
+		}
+	}
+
+	@Test
+	@DisplayName("[Success] 관리자가 회원 상태를 ACTIVE로 변경에 성공한다")
+	void changeStatus_Success_ActivateMember() {
+		Long adminId = 1L;
+		Long targetMemberId = 2L;
+
+		try (MockedStatic<AuthenticationContextHolder> mockedContext = mockStatic(AuthenticationContextHolder.class)) {
+			mockedContext.when(AuthenticationContextHolder::getCurrentMemberId).thenReturn(Optional.of(adminId));
+			when(memberQueryRepository.findById(adminId)).thenReturn(Optional.of(adminMember));
+			when(memberQueryRepository.findById(targetMemberId)).thenReturn(Optional.of(targetMember));
+			when(adminMember.getRole()).thenReturn(SystemRole.ADMIN);
+
+			MemberStatusChange.Request request = new MemberStatusChange.Request(targetMemberId, MemberStatus.ACTIVE);
+
+			memberStatusChangeService.changeStatus(request);
+
+			verify(targetMember).activate();
+			verify(memberCommandRepository).save(targetMember);
+		}
+	}
+
+	@Test
+	@DisplayName("[Failure] 인증되지 않은 사용자는 AuthenticationException이 발생한다")
+	void changeStatus_Fail_Unauthenticated() {
+		try (MockedStatic<AuthenticationContextHolder> mockedContext = mockStatic(AuthenticationContextHolder.class)) {
+			mockedContext.when(AuthenticationContextHolder::getCurrentMemberId).thenReturn(Optional.empty());
+
+			MemberStatusChange.Request request = new MemberStatusChange.Request(2L, MemberStatus.BANNED);
+
+			assertThatThrownBy(() -> memberStatusChangeService.changeStatus(request))
+				.isInstanceOf(AuthenticationException.class)
+				.hasFieldOrPropertyWithValue("problemCode", AuthProblemCode.AUTHENTICATION_CONTEXT_NOT_FOUND);
+
+			verify(memberQueryRepository, never()).findById(anyLong());
+			verify(memberCommandRepository, never()).save(any());
+		}
+	}
+
+	@Test
+	@DisplayName("[Failure] 관리자가 아닌 사용자는 AuthorizationException이 발생한다")
+	void changeStatus_Fail_NotAdmin() {
+		Long memberId = 1L;
+
+		try (MockedStatic<AuthenticationContextHolder> mockedContext = mockStatic(AuthenticationContextHolder.class)) {
+			mockedContext.when(AuthenticationContextHolder::getCurrentMemberId).thenReturn(Optional.of(memberId));
+			when(memberQueryRepository.findById(memberId)).thenReturn(Optional.of(adminMember));
+			when(adminMember.getRole()).thenReturn(SystemRole.MEMBER);
+
+			MemberStatusChange.Request request = new MemberStatusChange.Request(2L, MemberStatus.BANNED);
+
+			assertThatThrownBy(() -> memberStatusChangeService.changeStatus(request))
+				.isInstanceOf(AuthorizationException.class)
+				.hasFieldOrPropertyWithValue("problemCode", AuthProblemCode.AUTHORIZATION_REQUIRED);
+
+			verify(memberCommandRepository, never()).save(any());
+		}
+	}
+
+	@Test
+	@DisplayName("[Failure] 존재하지 않는 대상 회원에 대해 DomainException이 발생한다")
+	void changeStatus_Fail_TargetMemberNotFound() {
+		Long adminId = 1L;
+		Long targetMemberId = 999L;
+
+		try (MockedStatic<AuthenticationContextHolder> mockedContext = mockStatic(AuthenticationContextHolder.class)) {
+			mockedContext.when(AuthenticationContextHolder::getCurrentMemberId).thenReturn(Optional.of(adminId));
+			when(memberQueryRepository.findById(adminId)).thenReturn(Optional.of(adminMember));
+			when(memberQueryRepository.findById(targetMemberId)).thenReturn(Optional.empty());
+			when(adminMember.getRole()).thenReturn(SystemRole.ADMIN);
+
+			MemberStatusChange.Request request = new MemberStatusChange.Request(targetMemberId, MemberStatus.BANNED);
+
+			assertThatThrownBy(() -> memberStatusChangeService.changeStatus(request))
+				.isInstanceOf(DomainException.class)
+				.hasFieldOrPropertyWithValue("problemCode", MemberProblemCode.MEMBER_NOT_FOUND);
+
+			verify(memberCommandRepository, never()).save(any());
+		}
+	}
+}

--- a/src/test/java/me/chan99k/learningmanager/application/member/MemberWithdrawalServiceTest.java
+++ b/src/test/java/me/chan99k/learningmanager/application/member/MemberWithdrawalServiceTest.java
@@ -1,0 +1,125 @@
+package me.chan99k.learningmanager.application.member;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import me.chan99k.learningmanager.adapter.auth.AuthProblemCode;
+import me.chan99k.learningmanager.adapter.auth.AuthenticationContextHolder;
+import me.chan99k.learningmanager.application.course.requires.CourseQueryRepository;
+import me.chan99k.learningmanager.application.member.requires.MemberCommandRepository;
+import me.chan99k.learningmanager.application.member.requires.MemberQueryRepository;
+import me.chan99k.learningmanager.common.exception.AuthenticationException;
+import me.chan99k.learningmanager.common.exception.DomainException;
+import me.chan99k.learningmanager.domain.course.Course;
+import me.chan99k.learningmanager.domain.member.Account;
+import me.chan99k.learningmanager.domain.member.Member;
+import me.chan99k.learningmanager.domain.member.MemberProblemCode;
+
+@ExtendWith(MockitoExtension.class)
+class MemberWithdrawalServiceTest {
+
+	@InjectMocks
+	private MemberWithdrawalService memberWithdrawalService;
+
+	@Mock
+	private MemberQueryRepository memberQueryRepository;
+
+	@Mock
+	private MemberCommandRepository memberCommandRepository;
+
+	@Mock
+	private CourseQueryRepository courseQueryRepository;
+
+	@Mock
+	private Member member;
+
+	@Mock
+	private Account account;
+
+	@Mock
+	private Course course;
+
+	@Test
+	@DisplayName("[Success] 회원 탈퇴에 성공한다")
+	void withdrawal_Success() {
+		Long memberId = 1L;
+
+		try (MockedStatic<AuthenticationContextHolder> mockedContext = mockStatic(AuthenticationContextHolder.class)) {
+			mockedContext.when(AuthenticationContextHolder::getCurrentMemberId).thenReturn(Optional.of(memberId));
+			when(memberQueryRepository.findById(memberId)).thenReturn(Optional.of(member));
+			when(courseQueryRepository.findManagedCoursesByMemberId(memberId)).thenReturn(Collections.emptyList());
+			when(member.getAccounts()).thenReturn(List.of(account));
+			when(account.getId()).thenReturn(1L);
+
+			memberWithdrawalService.withdrawal();
+
+			verify(member).withdraw();
+			verify(member).deactivateAccount(1L);
+			verify(memberCommandRepository).save(member);
+		}
+	}
+
+	@Test
+	@DisplayName("[Failure] 인증되지 않은 사용자는 AuthenticationException이 발생한다")
+	void withdrawal_Fail_Unauthenticated() {
+		try (MockedStatic<AuthenticationContextHolder> mockedContext = mockStatic(AuthenticationContextHolder.class)) {
+			mockedContext.when(AuthenticationContextHolder::getCurrentMemberId).thenReturn(Optional.empty());
+
+			assertThatThrownBy(() -> memberWithdrawalService.withdrawal())
+				.isInstanceOf(AuthenticationException.class)
+				.hasFieldOrPropertyWithValue("problemCode", AuthProblemCode.AUTHENTICATION_CONTEXT_NOT_FOUND);
+
+			verify(memberQueryRepository, never()).findById(anyLong());
+			verify(memberCommandRepository, never()).save(any());
+		}
+	}
+
+	@Test
+	@DisplayName("[Failure] 존재하지 않는 회원은 DomainException이 발생한다")
+	void withdrawal_Fail_MemberNotFound() {
+		Long memberId = 999L;
+
+		try (MockedStatic<AuthenticationContextHolder> mockedContext = mockStatic(AuthenticationContextHolder.class)) {
+			mockedContext.when(AuthenticationContextHolder::getCurrentMemberId).thenReturn(Optional.of(memberId));
+			when(memberQueryRepository.findById(memberId)).thenReturn(Optional.empty());
+
+			assertThatThrownBy(() -> memberWithdrawalService.withdrawal())
+				.isInstanceOf(DomainException.class)
+				.hasFieldOrPropertyWithValue("problemCode", MemberProblemCode.MEMBER_NOT_FOUND);
+
+			verify(memberCommandRepository, never()).save(any());
+		}
+	}
+
+	@Test
+	@DisplayName("[Failure] 스터디장으로 활동 중인 과정이 있으면 IllegalStateException이 발생한다")
+	void withdrawal_Fail_HasManagedCourses() {
+		Long memberId = 1L;
+
+		try (MockedStatic<AuthenticationContextHolder> mockedContext = mockStatic(AuthenticationContextHolder.class)) {
+			mockedContext.when(AuthenticationContextHolder::getCurrentMemberId).thenReturn(Optional.of(memberId));
+			when(memberQueryRepository.findById(memberId)).thenReturn(Optional.of(member));
+			when(courseQueryRepository.findManagedCoursesByMemberId(memberId)).thenReturn(List.of(course));
+
+			assertThatThrownBy(() -> memberWithdrawalService.withdrawal())
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessage("스터디장 권한을 다른 멤버에게 위임한 후 탈퇴할 수 있습니다.");
+
+			verify(member, never()).withdraw();
+			verify(memberCommandRepository, never()).save(any());
+		}
+	}
+}

--- a/src/test/java/me/chan99k/learningmanager/application/member/MemberWithdrawalServiceTest.java
+++ b/src/test/java/me/chan99k/learningmanager/application/member/MemberWithdrawalServiceTest.java
@@ -18,7 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import me.chan99k.learningmanager.adapter.auth.AuthProblemCode;
 import me.chan99k.learningmanager.adapter.auth.AuthenticationContextHolder;
-import me.chan99k.learningmanager.application.course.requires.CourseQueryRepository;
+import me.chan99k.learningmanager.application.member.requires.CourseQueryRepository;
 import me.chan99k.learningmanager.application.member.requires.MemberCommandRepository;
 import me.chan99k.learningmanager.application.member.requires.MemberQueryRepository;
 import me.chan99k.learningmanager.common.exception.AuthenticationException;


### PR DESCRIPTION
## 💡 Motivation and Context
이번 PR은  회원 상태 변경 및 탈퇴 기능을 제공합니다.

<br>

## 🔨 Modified
> ### 기능 구현
- **회원 상태 변경**
    - `MemberAdminController` 추가 (관리자 전용 엔드포인트: `/api/v1/admin/members`)
    - `MemberStatusChangeService` 구현 (상태 변경 로직 및 권한 검증)
    - 도메인 `Member` 엔티티 상태 전환 메서드 (`activate`, `deactivate`, `ban`, `withdraw`) 구현

- **회원 탈퇴**
    - `MemberProfileController`에 탈퇴 엔드포인트 추가
    - `MemberWithdrawalService` 구현 (자체 탈퇴 처리, 과정 관리자 검증, 연관 계정 비활성화 로직 포함)


<br>


### 📋 체크리스트
- [x] 단위 및 통합 테스트 작성 및 통과
- [x] 코드 컨벤션 및 패키지 구조 준수

<br>

### 🤟🏻 PR로 완료된 이슈
> #40 #41 