### PR TITLE
과정 상세 정보 및 멤버 목록 조회 기능 구현

### DIFF
--- a/src/main/java/me/chan99k/learningmanager/adapter/persistence/course/CourseQueryAdapter.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/persistence/course/CourseQueryAdapter.java
@@ -1,10 +1,15 @@
 package me.chan99k.learningmanager.adapter.persistence.course;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import me.chan99k.learningmanager.application.course.CourseDetailInfo;
+import me.chan99k.learningmanager.application.course.CourseMemberInfo;
 import me.chan99k.learningmanager.application.course.requires.CourseQueryRepository;
 import me.chan99k.learningmanager.domain.course.Course;
 
@@ -35,5 +40,34 @@ public class CourseQueryAdapter implements CourseQueryRepository {
 	@Override
 	public List<Course> findManagedCoursesByMemberId(Long memberId) {
 		return jpaCourseRepository.findManagedCoursesByMemberId(memberId);
+	}
+
+	@Override
+	public Optional<CourseDetailInfo> findCourseDetailById(Long courseId) {
+		Optional<Object[]> basicDetails = jpaCourseRepository.findCourseBasicDetailsById(courseId);
+		if (basicDetails.isEmpty()) {
+			return Optional.empty();
+		}
+
+		Object[] row = basicDetails.get();
+		Long id = ((Number)row[0]).longValue();
+		String title = (String)row[1];
+		String description = (String)row[2];
+		Instant createdAt = (Instant)row[3];
+		int totalMembers = ((Number)row[4]).intValue();
+		int totalCurricula = ((Number)row[5]).intValue();
+		int totalSessions = ((Number)row[6]).intValue();
+
+		CourseDetailInfo courseDetailInfo = new CourseDetailInfo(
+			id, title, description, createdAt,
+			totalMembers, totalCurricula, totalSessions
+		);
+
+		return Optional.of(courseDetailInfo);
+	}
+
+	@Override
+	public Page<CourseMemberInfo> findCourseMembersByCourseId(Long courseId, Pageable pageable) {
+		return jpaCourseRepository.findCourseMembersByCourseId(courseId, pageable);
 	}
 }

--- a/src/main/java/me/chan99k/learningmanager/adapter/persistence/course/JpaCourseRepository.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/persistence/course/JpaCourseRepository.java
@@ -3,10 +3,13 @@ package me.chan99k.learningmanager.adapter.persistence.course;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import me.chan99k.learningmanager.application.course.CourseMemberInfo;
 import me.chan99k.learningmanager.application.member.CourseParticipationInfo;
 import me.chan99k.learningmanager.domain.course.Course;
 
@@ -31,4 +34,24 @@ public interface JpaCourseRepository extends JpaRepository<Course, Long> {
 		"FROM Course c JOIN c.courseMemberList cm " +
 		"WHERE cm.memberId = :memberId")
 	List<CourseParticipationInfo> findParticipatingCoursesWithRoleByMemberId(@Param("memberId") Long memberId);
+
+	@Query(value = "SELECT c.id, c.title, c.description, c.created_at, " +
+		"COUNT(DISTINCT cm.id) as totalMembers, " +
+		"COUNT(DISTINCT cur.id) as totalCurricula, " +
+		"(SELECT COUNT(*) FROM session s WHERE s.course_id = c.id) as totalSessions " +
+		"FROM course c " +
+		"LEFT JOIN course_member cm ON c.id = cm.course_id " +
+		"LEFT JOIN curriculum cur ON c.id = cur.course_id " +
+		"WHERE c.id = ?1 " +
+		"GROUP BY c.id, c.title, c.description, c.created_at", nativeQuery = true)
+	Optional<Object[]> findCourseBasicDetailsById(Long courseId);
+
+	@Query("SELECT new me.chan99k.learningmanager.application.course.CourseMemberInfo(" +
+		"cm.memberId, m.nickname.value, a.email.address, cm.courseRole, cm.createdAt) " +
+		"FROM CourseMember cm " +
+		"JOIN Member m ON cm.memberId = m.id " +
+		"JOIN Account a ON a.member.id = m.id " +
+		"WHERE cm.course.id = :courseId " +
+		"ORDER BY cm.createdAt DESC")
+	Page<CourseMemberInfo> findCourseMembersByCourseId(@Param("courseId") Long courseId, Pageable pageable);
 }

--- a/src/main/java/me/chan99k/learningmanager/adapter/web/course/CourseDetailController.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/web/course/CourseDetailController.java
@@ -1,0 +1,53 @@
+package me.chan99k.learningmanager.adapter.web.course;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import me.chan99k.learningmanager.application.course.CourseMemberInfo;
+import me.chan99k.learningmanager.application.course.provides.CourseDetailRetrieval;
+
+@RestController
+@RequestMapping("/api/v1/courses")
+public class CourseDetailController {
+
+	private final CourseDetailRetrieval courseDetailRetrieval;
+	private final TaskExecutor courseTaskExecutor;
+
+	public CourseDetailController(
+		CourseDetailRetrieval courseDetailRetrieval,
+		TaskExecutor courseTaskExecutor
+	) {
+		this.courseDetailRetrieval = courseDetailRetrieval;
+		this.courseTaskExecutor = courseTaskExecutor;
+	}
+
+	@GetMapping("/{courseId}")
+	public CompletableFuture<ResponseEntity<CourseDetailRetrieval.CourseDetailResponse>> getCourseDetail(
+		@PathVariable Long courseId
+	) {
+		return CompletableFuture.supplyAsync(() -> {
+			CourseDetailRetrieval.CourseDetailResponse response = courseDetailRetrieval.getCourseDetail(courseId);
+			return ResponseEntity.ok(response);
+		}, courseTaskExecutor);
+	}
+
+	@GetMapping("/{courseId}/members")
+	public CompletableFuture<ResponseEntity<Page<CourseMemberInfo>>> getCourseMembers(
+		@PathVariable Long courseId,
+		@PageableDefault(size = 20) Pageable pageable
+	) {
+		return CompletableFuture.supplyAsync(() -> {
+			Page<CourseMemberInfo> response = courseDetailRetrieval.getCourseMembers(courseId, pageable);
+			return ResponseEntity.ok(response);
+		}, courseTaskExecutor);
+	}
+}

--- a/src/main/java/me/chan99k/learningmanager/application/course/CourseDetailInfo.java
+++ b/src/main/java/me/chan99k/learningmanager/application/course/CourseDetailInfo.java
@@ -1,0 +1,14 @@
+package me.chan99k.learningmanager.application.course;
+
+import java.time.Instant;
+
+public record CourseDetailInfo(
+	Long courseId,
+	String title,
+	String description,
+	Instant createdAt,
+	int totalMembers,
+	int totalCurricula,
+	int totalSessions
+) {
+}

--- a/src/main/java/me/chan99k/learningmanager/application/course/CourseDetailService.java
+++ b/src/main/java/me/chan99k/learningmanager/application/course/CourseDetailService.java
@@ -1,0 +1,38 @@
+package me.chan99k.learningmanager.application.course;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import me.chan99k.learningmanager.application.course.provides.CourseDetailRetrieval;
+import me.chan99k.learningmanager.application.course.requires.CourseQueryRepository;
+import me.chan99k.learningmanager.common.exception.DomainException;
+import me.chan99k.learningmanager.domain.course.CourseProblemCode;
+
+@Service
+@Transactional(readOnly = true)
+public class CourseDetailService implements CourseDetailRetrieval {
+
+	private final CourseQueryRepository courseQueryRepository;
+
+	public CourseDetailService(CourseQueryRepository courseQueryRepository) {
+		this.courseQueryRepository = courseQueryRepository;
+	}
+
+	@Override
+	public CourseDetailResponse getCourseDetail(Long courseId) {
+		CourseDetailInfo courseDetail = courseQueryRepository.findCourseDetailById(courseId)
+			.orElseThrow(() -> new DomainException(CourseProblemCode.COURSE_NOT_FOUND));
+
+		return new CourseDetailResponse(courseDetail);
+	}
+
+	@Override
+	public Page<CourseMemberInfo> getCourseMembers(Long courseId, Pageable pageable) {
+		courseQueryRepository.findById(courseId)
+			.orElseThrow(() -> new DomainException(CourseProblemCode.COURSE_NOT_FOUND));
+
+		return courseQueryRepository.findCourseMembersByCourseId(courseId, pageable);
+	}
+}

--- a/src/main/java/me/chan99k/learningmanager/application/course/CourseMemberInfo.java
+++ b/src/main/java/me/chan99k/learningmanager/application/course/CourseMemberInfo.java
@@ -1,0 +1,14 @@
+package me.chan99k.learningmanager.application.course;
+
+import java.time.Instant;
+
+import me.chan99k.learningmanager.domain.course.CourseRole;
+
+public record CourseMemberInfo(
+	Long memberId,
+	String nickname,
+	String email,
+	CourseRole courseRole,
+	Instant joinedAt
+) {
+}

--- a/src/main/java/me/chan99k/learningmanager/application/course/provides/CourseDetailRetrieval.java
+++ b/src/main/java/me/chan99k/learningmanager/application/course/provides/CourseDetailRetrieval.java
@@ -1,0 +1,23 @@
+package me.chan99k.learningmanager.application.course.provides;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import me.chan99k.learningmanager.application.course.CourseDetailInfo;
+import me.chan99k.learningmanager.application.course.CourseMemberInfo;
+
+/**
+ * 과정 상세 정보 조회 포트
+ * - 과정 기본 정보 + 집계 데이터 조회
+ * - 과정 멤버 목록 페이징 조회
+ * - N+1 문제 방지를 위한 최적화된 쿼리 사용
+ */
+public interface CourseDetailRetrieval {
+
+	CourseDetailResponse getCourseDetail(Long courseId);
+
+	Page<CourseMemberInfo> getCourseMembers(Long courseId, Pageable pageable);
+
+	record CourseDetailResponse(CourseDetailInfo courseDetail) {
+	}
+}

--- a/src/main/java/me/chan99k/learningmanager/application/course/requires/CourseQueryRepository.java
+++ b/src/main/java/me/chan99k/learningmanager/application/course/requires/CourseQueryRepository.java
@@ -3,6 +3,11 @@ package me.chan99k.learningmanager.application.course.requires;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import me.chan99k.learningmanager.application.course.CourseDetailInfo;
+import me.chan99k.learningmanager.application.course.CourseMemberInfo;
 import me.chan99k.learningmanager.domain.course.Course;
 
 public interface CourseQueryRepository {
@@ -13,5 +18,9 @@ public interface CourseQueryRepository {
 	Optional<Course> findManagedCourseById(Long courseId, Long memberId);
 
 	List<Course> findManagedCoursesByMemberId(Long memberId);
+
+	Optional<CourseDetailInfo> findCourseDetailById(Long courseId);
+
+	Page<CourseMemberInfo> findCourseMembersByCourseId(Long courseId, Pageable pageable);
 
 }

--- a/src/test/java/me/chan99k/learningmanager/adapter/web/course/CourseDetailControllerTest.java
+++ b/src/test/java/me/chan99k/learningmanager/adapter/web/course/CourseDetailControllerTest.java
@@ -1,0 +1,78 @@
+package me.chan99k.learningmanager.adapter.web.course;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
+import me.chan99k.learningmanager.application.course.CourseDetailInfo;
+import me.chan99k.learningmanager.application.course.CourseMemberInfo;
+import me.chan99k.learningmanager.application.course.provides.CourseDetailRetrieval;
+import me.chan99k.learningmanager.domain.course.CourseRole;
+
+@ExtendWith(MockitoExtension.class)
+class CourseDetailControllerTest {
+
+	@Mock
+	private CourseDetailRetrieval courseDetailRetrieval;
+
+	@Test
+	@DisplayName("[Success] 과정 상세 정보 조회가 정상 동작한다")
+	void getCourseDetail() throws Exception {
+		Long courseId = 1L;
+		CourseDetailInfo courseDetail = new CourseDetailInfo(
+			courseId, "Spring Boot 기초", "스프링 부트 학습 과정",
+			Instant.now(), 10, 5, 15
+		);
+		CourseDetailRetrieval.CourseDetailResponse response =
+			new CourseDetailRetrieval.CourseDetailResponse(courseDetail);
+
+		given(courseDetailRetrieval.getCourseDetail(courseId)).willReturn(response);
+
+		CourseDetailController controller = new CourseDetailController(courseDetailRetrieval, new SyncTaskExecutor());
+		ResponseEntity<CourseDetailRetrieval.CourseDetailResponse> result =
+			controller.getCourseDetail(courseId).get();
+
+		assertThat(result.getStatusCode().value()).isEqualTo(200);
+		assertThat(result.getBody().courseDetail()).isEqualTo(courseDetail);
+		verify(courseDetailRetrieval).getCourseDetail(courseId);
+	}
+
+	@Test
+	@DisplayName("[Success] 과정 멤버 목록 조회가 정상 동작한다")
+	void getCourseMembers() throws Exception {
+		Long courseId = 1L;
+		Pageable pageable = PageRequest.of(0, 20);
+		List<CourseMemberInfo> members = List.of(
+			new CourseMemberInfo(1L, "사용자1", "user1@test.com", CourseRole.MENTEE, Instant.now()),
+			new CourseMemberInfo(2L, "사용자2", "user2@test.com", CourseRole.MANAGER, Instant.now())
+		);
+		Page<CourseMemberInfo> memberPage = new PageImpl<>(members, pageable, 2);
+
+		given(courseDetailRetrieval.getCourseMembers(courseId, pageable))
+			.willReturn(memberPage);
+
+		CourseDetailController controller = new CourseDetailController(courseDetailRetrieval, new SyncTaskExecutor());
+		ResponseEntity<Page<CourseMemberInfo>> result =
+			controller.getCourseMembers(courseId, pageable).get();
+
+		assertThat(result.getStatusCode().value()).isEqualTo(200);
+		assertThat(result.getBody().getContent()).hasSize(2);
+		assertThat(result.getBody().getContent().get(0).nickname()).isEqualTo("사용자1");
+		assertThat(result.getBody().getTotalElements()).isEqualTo(2);
+		verify(courseDetailRetrieval).getCourseMembers(courseId, pageable);
+	}
+}

--- a/src/test/java/me/chan99k/learningmanager/application/course/CourseDetailServiceTest.java
+++ b/src/test/java/me/chan99k/learningmanager/application/course/CourseDetailServiceTest.java
@@ -1,0 +1,105 @@
+package me.chan99k.learningmanager.application.course;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import me.chan99k.learningmanager.application.course.provides.CourseDetailRetrieval;
+import me.chan99k.learningmanager.application.course.requires.CourseQueryRepository;
+import me.chan99k.learningmanager.common.exception.DomainException;
+import me.chan99k.learningmanager.domain.course.Course;
+import me.chan99k.learningmanager.domain.course.CourseRole;
+
+@ExtendWith(MockitoExtension.class)
+class CourseDetailServiceTest {
+
+	@Mock
+	private CourseQueryRepository courseQueryRepository;
+
+	@InjectMocks
+	private CourseDetailService courseDetailService;
+
+	@Test
+	@DisplayName("과정 상세 정보를 성공적으로 조회한다")
+	void getCourseDetail_Success() {
+		// given
+		Long courseId = 1L;
+		CourseDetailInfo courseDetailInfo = new CourseDetailInfo(
+			courseId, "Spring Boot 기초", "스프링 부트 학습 과정",
+			Instant.now(), 10, 5, 15
+		);
+		given(courseQueryRepository.findCourseDetailById(courseId))
+			.willReturn(Optional.of(courseDetailInfo));
+
+		// when
+		CourseDetailRetrieval.CourseDetailResponse response = courseDetailService.getCourseDetail(courseId);
+
+		// then
+		assertThat(response.courseDetail()).isEqualTo(courseDetailInfo);
+		verify(courseQueryRepository).findCourseDetailById(courseId);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 과정 조회 시 예외가 발생한다")
+	void getCourseDetail_CourseNotFound() {
+		// given
+		Long courseId = 999L;
+		given(courseQueryRepository.findCourseDetailById(courseId))
+			.willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> courseDetailService.getCourseDetail(courseId))
+			.isInstanceOf(DomainException.class);
+	}
+
+	@Test
+	@DisplayName("과정 멤버 목록을 페이징으로 조회한다")
+	void getCourseMembers_Success() {
+		// given
+		Long courseId = 1L;
+		Pageable pageable = PageRequest.of(0, 10);
+		Course course = Course.create("Test Course", "Description");
+		Page<CourseMemberInfo> memberPage = new PageImpl<>(java.util.List.of(
+			new CourseMemberInfo(1L, "사용자1", "user1@test.com", CourseRole.MENTEE, Instant.now()),
+			new CourseMemberInfo(2L, "사용자2", "user2@test.com", CourseRole.MANAGER, Instant.now())
+		));
+
+		given(courseQueryRepository.findById(courseId)).willReturn(Optional.of(course));
+		given(courseQueryRepository.findCourseMembersByCourseId(courseId, pageable))
+			.willReturn(memberPage);
+
+		// when
+		Page<CourseMemberInfo> result = courseDetailService.getCourseMembers(courseId, pageable);
+
+		// then
+		assertThat(result.getContent()).hasSize(2);
+		assertThat(result.getContent().get(0).nickname()).isEqualTo("사용자1");
+		assertThat(result.getContent().get(1).courseRole()).isEqualTo(CourseRole.MANAGER);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 과정의 멤버 조회 시 예외가 발생한다")
+	void getCourseMembers_CourseNotFound() {
+		// given
+		Long courseId = 999L;
+		Pageable pageable = PageRequest.of(0, 10);
+		given(courseQueryRepository.findById(courseId)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> courseDetailService.getCourseMembers(courseId, pageable))
+			.isInstanceOf(DomainException.class);
+	}
+}


### PR DESCRIPTION
## 💡 Motivation and Context
> 이 PR에서는 과정 상세 정보(과정/커리큘럼 정보, 참여 멤버 목록)를 조회하는 기능을 제공합니다.

<br>

## 🔨 Modified
> - 과정 상세 정보를 조회하기 위한 데이터 접근 기능 추가
> - 과정 상세 조회를 위한 서비스 및 유스케이스 계층 생성
> - 과정 상세 조회 기능을 외부로 제공하는 웹 API 추가
> - 과정 상세 조회를 검증하기 위한 기본 테스트 작성

<br>


### 📋 체크리스트
- [ ] 추가/변경에 대한 테스트
- [ ] 코드 컨벤션

<br>

### 🤟🏻 PR로 완료된 이슈
> closes #45