### PR TITLE
상태 변경 요청에 대한 CompletableFuture 제거

### DIFF
--- a/src/main/java/me/chan99k/learningmanager/adapter/web/course/CourseCalendarController.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/web/course/CourseCalendarController.java
@@ -31,7 +31,8 @@ public class CourseCalendarController {
 	}
 
 	@GetMapping("/{courseId}/calendar")
-	public CompletableFuture<ResponseEntity<Map<LocalDate, List<SessionListRetrieval.SessionCalendarResponse>>>> getCourseCalendar(
+	public CompletableFuture<ResponseEntity<Map<LocalDate, List<SessionListRetrieval.SessionCalendarResponse>>>>
+	getCourseCalendar(
 		@PathVariable Long courseId,
 		@RequestParam int year,
 		@RequestParam int month,
@@ -50,7 +51,8 @@ public class CourseCalendarController {
 	}
 
 	@GetMapping("/{courseId}/curricula/{curriculumId}/calendar")
-	public CompletableFuture<ResponseEntity<Map<LocalDate, List<SessionListRetrieval.SessionCalendarResponse>>>> getCurriculumCalendar(
+	public CompletableFuture<ResponseEntity<Map<LocalDate, List<SessionListRetrieval.SessionCalendarResponse>>>>
+	getCurriculumCalendar(
 		@PathVariable Long courseId,
 		@PathVariable Long curriculumId,
 		@RequestParam int year,

--- a/src/main/java/me/chan99k/learningmanager/adapter/web/course/CourseCreateController.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/web/course/CourseCreateController.java
@@ -1,8 +1,5 @@
 package me.chan99k.learningmanager.adapter.web.course;
 
-import java.util.concurrent.CompletableFuture;
-
-import org.springframework.core.task.TaskExecutor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,21 +14,18 @@ import me.chan99k.learningmanager.application.course.provides.CourseCreation;
 @RestController
 @RequestMapping("/api/v1/courses")
 public class CourseCreateController {
-	private final CourseCreationService courseCreationService;
-	private final TaskExecutor courseTaskExecutor;
 
-	public CourseCreateController(CourseCreationService courseCreationService, TaskExecutor courseTaskExecutor) {
+	private final CourseCreationService courseCreationService;
+
+	public CourseCreateController(CourseCreationService courseCreationService) {
 		this.courseCreationService = courseCreationService;
-		this.courseTaskExecutor = courseTaskExecutor;
 	}
 
 	@PostMapping
-	public CompletableFuture<ResponseEntity<CourseCreation.Response>> createCourse(
+	public ResponseEntity<CourseCreation.Response> createCourse(
 		@Valid @RequestBody CourseCreation.Request request
 	) {
-		return CompletableFuture.supplyAsync(() -> {
-			CourseCreation.Response response = courseCreationService.createCourse(request);
-			return ResponseEntity.status(HttpStatus.CREATED).body(response);
-		}, courseTaskExecutor);
+		CourseCreation.Response response = courseCreationService.createCourse(request);
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 }

--- a/src/main/java/me/chan99k/learningmanager/adapter/web/course/CourseCurriculumAdditionController.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/web/course/CourseCurriculumAdditionController.java
@@ -1,8 +1,5 @@
 package me.chan99k.learningmanager.adapter.web.course;
 
-import java.util.concurrent.CompletableFuture;
-
-import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,23 +14,21 @@ import me.chan99k.learningmanager.application.course.provides.CurriculumCreation
 @RestController
 @RequestMapping("/api/v1/courses")
 public class CourseCurriculumAdditionController {
-	private final CurriculumCreation curriculumCreation;
-	private final AsyncTaskExecutor courseTaskExecutor;
 
-	public CourseCurriculumAdditionController(CurriculumCreation curriculumCreation,
-		AsyncTaskExecutor courseTaskExecutor) {
+	private final CurriculumCreation curriculumCreation;
+
+	public CourseCurriculumAdditionController(CurriculumCreation curriculumCreation) {
 		this.curriculumCreation = curriculumCreation;
-		this.courseTaskExecutor = courseTaskExecutor;
+
 	}
 
 	@PostMapping("/{courseId}/curriculums")
-	public CompletableFuture<ResponseEntity<CurriculumCreation.Response>> addCourseCurriculum(
+	public ResponseEntity<CurriculumCreation.Response> addCourseCurriculum(
 		@PathVariable Long courseId,
 		@Valid @RequestBody CurriculumCreation.Request request
 	) {
-		return CompletableFuture.supplyAsync(() -> {
-			CurriculumCreation.Response response = curriculumCreation.createCurriculum(courseId, request);
-			return ResponseEntity.status(HttpStatus.CREATED).body(response);
-		}, courseTaskExecutor);
+		CurriculumCreation.Response response = curriculumCreation.createCurriculum(courseId, request);
+
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 }

--- a/src/main/java/me/chan99k/learningmanager/adapter/web/course/CourseDeletionController.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/web/course/CourseDeletionController.java
@@ -1,8 +1,5 @@
 package me.chan99k.learningmanager.adapter.web.course;
 
-import java.util.concurrent.CompletableFuture;
-
-import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,22 +11,18 @@ import me.chan99k.learningmanager.application.course.provides.CourseDeletion;
 @RestController
 @RequestMapping("/api/v1/courses")
 public class CourseDeletionController {
-	private final CourseDeletion courseDeletion;
-	private final AsyncTaskExecutor courseTaskExecutor;
 
-	public CourseDeletionController(CourseDeletion courseDeletion,
-		AsyncTaskExecutor courseTaskExecutor) {
+	private final CourseDeletion courseDeletion;
+
+	public CourseDeletionController(CourseDeletion courseDeletion) {
 		this.courseDeletion = courseDeletion;
-		this.courseTaskExecutor = courseTaskExecutor;
 	}
 
 	@DeleteMapping("/{courseId}")
-	public CompletableFuture<ResponseEntity<Void>> deleteCourse(
+	public ResponseEntity<Void> deleteCourse(
 		@PathVariable Long courseId
 	) {
-		return CompletableFuture.supplyAsync(() -> {
-			courseDeletion.deleteCourse(courseId);
-			return ResponseEntity.noContent().build();
-		}, courseTaskExecutor);
+		courseDeletion.deleteCourse(courseId);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/me/chan99k/learningmanager/adapter/web/course/CourseInfoUpdateController.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/web/course/CourseInfoUpdateController.java
@@ -1,8 +1,5 @@
 package me.chan99k.learningmanager.adapter.web.course;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -17,22 +14,18 @@ import me.chan99k.learningmanager.application.course.provides.CourseInfoUpdate;
 public class CourseInfoUpdateController {
 
 	private final CourseInfoUpdate courseInfoUpdate;
-	private final Executor courseTaskExecutor;
 
-	public CourseInfoUpdateController(
-		CourseInfoUpdate courseInfoUpdate,
-		Executor courseTaskExecutor) {
+	public CourseInfoUpdateController(CourseInfoUpdate courseInfoUpdate) {
 		this.courseInfoUpdate = courseInfoUpdate;
-		this.courseTaskExecutor = courseTaskExecutor;
+
 	}
 
 	@PutMapping("/{courseId}")
-	public CompletableFuture<ResponseEntity<Void>> updateCourse(
+	public ResponseEntity<Void> updateCourse(
 		@PathVariable Long courseId,
-		@RequestBody CourseInfoUpdate.Request request) {
-		return CompletableFuture.supplyAsync(() -> {
-			courseInfoUpdate.updateCourseInfo(courseId, request);
-			return ResponseEntity.ok().build();
-		}, courseTaskExecutor);
+		@RequestBody CourseInfoUpdate.Request request
+	) {
+		courseInfoUpdate.updateCourseInfo(courseId, request);
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/me/chan99k/learningmanager/adapter/web/course/CurriculumUpdateController.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/web/course/CurriculumUpdateController.java
@@ -1,8 +1,5 @@
 package me.chan99k.learningmanager.adapter.web.course;
 
-import java.util.concurrent.CompletableFuture;
-
-import org.springframework.core.task.TaskExecutor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -10,7 +7,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import jakarta.validation.Valid;
 import me.chan99k.learningmanager.application.course.provides.CurriculumInfoUpdate;
 
 @RestController
@@ -18,23 +14,19 @@ import me.chan99k.learningmanager.application.course.provides.CurriculumInfoUpda
 public class CurriculumUpdateController {
 
 	private final CurriculumInfoUpdate curriculumInfoUpdate;
-	private final TaskExecutor courseTaskExecutor;
 
 	public CurriculumUpdateController(
-		CurriculumInfoUpdate curriculumInfoUpdate,
-		TaskExecutor courseTaskExecutor) {
+		CurriculumInfoUpdate curriculumInfoUpdate) {
 		this.curriculumInfoUpdate = curriculumInfoUpdate;
-		this.courseTaskExecutor = courseTaskExecutor;
 	}
 
 	@PutMapping("/{courseId}/curriculums/{curriculumId}")
-	public CompletableFuture<ResponseEntity<Void>> updateCurriculum(
+	public ResponseEntity<Void> updateCurriculum(
 		@PathVariable Long courseId,
 		@PathVariable Long curriculumId,
-		@RequestBody CurriculumInfoUpdate.Request request) {
-		return CompletableFuture.supplyAsync(() -> {
-			curriculumInfoUpdate.updateCurriculumInfo(courseId, curriculumId, request);
-			return ResponseEntity.ok().build();
-		}, courseTaskExecutor);
+		@RequestBody CurriculumInfoUpdate.Request request
+	) {
+		curriculumInfoUpdate.updateCurriculumInfo(courseId, curriculumId, request);
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/me/chan99k/learningmanager/adapter/web/member/MemberCourseParticipationController.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/web/member/MemberCourseParticipationController.java
@@ -1,5 +1,8 @@
 package me.chan99k.learningmanager.adapter.web.member;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,16 +17,22 @@ import me.chan99k.learningmanager.application.member.MemberCourseParticipationSe
 public class MemberCourseParticipationController {
 
 	private final MemberCourseParticipationService memberCourseParticipationService;
+	private final Executor memberTaskExecutor;
 
-	public MemberCourseParticipationController(MemberCourseParticipationService memberCourseParticipationService) {
+	public MemberCourseParticipationController(MemberCourseParticipationService memberCourseParticipationService,
+		Executor memberTaskExecutor) {
 		this.memberCourseParticipationService = memberCourseParticipationService;
+		this.memberTaskExecutor = memberTaskExecutor;
 	}
 
 	@GetMapping("/{memberId}/courses")
-	public ResponseEntity<ParticipatingCoursesResponse> getParticipatingCourses(
+	public CompletableFuture<ResponseEntity<ParticipatingCoursesResponse>> getParticipatingCourses(
 		@PathVariable Long memberId
 	) {
-		ParticipatingCoursesResponse response = memberCourseParticipationService.getParticipatingCourses(memberId);
-		return ResponseEntity.ok(response);
+		return CompletableFuture.supplyAsync(() -> {
+			ParticipatingCoursesResponse response = memberCourseParticipationService.getParticipatingCourses(memberId);
+			return ResponseEntity.ok(response);
+		}, memberTaskExecutor);
+
 	}
 }

--- a/src/main/java/me/chan99k/learningmanager/adapter/web/member/MemberLoginController.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/web/member/MemberLoginController.java
@@ -1,8 +1,5 @@
 package me.chan99k.learningmanager.adapter.web.member;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,20 +14,17 @@ import me.chan99k.learningmanager.application.member.provides.MemberLogin;
 @RequestMapping("/api/v1/members/auth")
 public class MemberLoginController {
 	private final MemberLogin memberLoginService;
-	private final Executor memberTaskExecutor;
 
-	public MemberLoginController(MemberLogin memberLoginService, Executor memberTaskExecutor) {
+	public MemberLoginController(MemberLogin memberLoginService) {
 		this.memberLoginService = memberLoginService;
-		this.memberTaskExecutor = memberTaskExecutor;
 	}
 
 	@PostMapping("/token")
-	public CompletableFuture<ResponseEntity<MemberLogin.Response>> login(
+	public ResponseEntity<MemberLogin.Response> login(
 		@RequestBody @Valid MemberLogin.Request request
 	) {
-		return CompletableFuture.supplyAsync(() -> {
-			MemberLogin.Response loginResponse = memberLoginService.login(request);
-			return ResponseEntity.status(HttpStatus.OK).body(loginResponse);
-		}, memberTaskExecutor);
+		MemberLogin.Response loginResponse = memberLoginService.login(request);
+
+		return ResponseEntity.status(HttpStatus.OK).body(loginResponse);
 	}
 }

--- a/src/main/java/me/chan99k/learningmanager/adapter/web/member/MemberProfileController.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/web/member/MemberProfileController.java
@@ -41,15 +41,13 @@ public class MemberProfileController {
 	}
 
 	@PostMapping("/profile")
-	public CompletableFuture<ResponseEntity<MemberProfileUpdate.Response>> updateProfile(
+	public ResponseEntity<MemberProfileUpdate.Response> updateProfile(
 		@RequestBody MemberProfileUpdate.Request request
 	) {
 		final Long memberId = extractMemberIdFromAuthentication();
+		MemberProfileUpdate.Response response = memberProfileUpdate.updateProfile(memberId, request);
 
-		return CompletableFuture.supplyAsync(() -> {
-			MemberProfileUpdate.Response response = memberProfileUpdate.updateProfile(memberId, request);
-			return ResponseEntity.ok(response);
-		}, memberTaskExecutor);
+		return ResponseEntity.ok(response);
 	}
 
 	@GetMapping("/profile")

--- a/src/main/java/me/chan99k/learningmanager/adapter/web/member/MemberRegisterController.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/web/member/MemberRegisterController.java
@@ -1,7 +1,5 @@
 package me.chan99k.learningmanager.adapter.web.member;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,32 +20,24 @@ import me.chan99k.learningmanager.application.member.provides.SignUpConfirmation
 public class MemberRegisterController {
 
 	private final MemberRegisterService memberRegisterService;
-	private final Executor memberTaskExecutor;
 
-	public MemberRegisterController(MemberRegisterService memberRegisterService, Executor memberTaskExecutor) {
+	public MemberRegisterController(MemberRegisterService memberRegisterService) {
 		this.memberRegisterService = memberRegisterService;
-		this.memberTaskExecutor = memberTaskExecutor;
 	}
 
 	@PostMapping("/register")
-	public CompletableFuture<ResponseEntity<MemberRegistration.Response>> register(
+	public ResponseEntity<MemberRegistration.Response> register(
 		@Valid @RequestBody MemberRegistration.Request request
 	) {
-		return CompletableFuture.supplyAsync(() -> {
-				MemberRegistration.Response response = memberRegisterService.register(request);
-				return ResponseEntity.status(HttpStatus.CREATED).body(response);
-			}, memberTaskExecutor
-		);
-
+		MemberRegistration.Response response = memberRegisterService.register(request);
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 
 	@GetMapping("/activate")
-	public CompletableFuture<ResponseEntity<Void>> activateMember(
+	public ResponseEntity<Void> activateMember(
 		@RequestParam String token
 	) {
-		return CompletableFuture.supplyAsync(() -> {
-			memberRegisterService.activateSignUpMember(new SignUpConfirmation.Request(token));
-			return ResponseEntity.ok().build();
-		}, memberTaskExecutor);
+		memberRegisterService.activateSignUpMember(new SignUpConfirmation.Request(token));
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/me/chan99k/learningmanager/adapter/web/session/SessionController.java
+++ b/src/main/java/me/chan99k/learningmanager/adapter/web/session/SessionController.java
@@ -59,43 +59,39 @@ public class SessionController {
 		this.sessionTaskExecutor = sessionTaskExecutor;
 	}
 
-	@GetMapping
-	public CompletableFuture<ResponseEntity<Page<SessionListRetrieval.SessionListResponse>>> getSessionList(
-		@RequestParam(defaultValue = "0") int page,
-		@RequestParam(defaultValue = "20") int size,
-		@RequestParam(defaultValue = "scheduledAt,desc") String sort,
-		@RequestParam(required = false) SessionType type,
-		@RequestParam(required = false) SessionLocation location,
-		@RequestParam(required = false) Instant startDate,
-		@RequestParam(required = false) Instant endDate
-	) {
-		return CompletableFuture.supplyAsync(() -> {
-			var request = new SessionListRetrieval.SessionListRequest(page, size, sort, type, location, startDate,
-				endDate);
-			Page<SessionListRetrieval.SessionListResponse> response = sessionListRetrieval.getSessionList(request);
-			return ResponseEntity.ok(response);
-		}, sessionTaskExecutor);
-	}
-
 	@PostMapping
-	public CompletableFuture<ResponseEntity<SessionCreation.Response>> createSession(
+	public ResponseEntity<SessionCreation.Response> createSession(
 		@Valid @RequestBody SessionCreation.Request request
 	) {
-		return CompletableFuture.supplyAsync(() -> {
-			Session session = sessionCreationService.createSession(request);
-			SessionCreation.Response response = new SessionCreation.Response(
-				session.getId(),
-				session.getTitle(),
-				session.getScheduledAt(),
-				session.getScheduledEndAt(),
-				session.getType(),
-				session.getLocation(),
-				session.getLocationDetails(),
-				session.getCourseId(),
-				session.getCurriculumId()
-			);
-			return ResponseEntity.status(HttpStatus.CREATED).body(response);
-		}, sessionTaskExecutor);
+		Session session = sessionCreationService.createSession(request);
+
+		SessionCreation.Response response = new SessionCreation.Response(
+			session.getId(),
+			session.getTitle(),
+			session.getScheduledAt(),
+			session.getScheduledEndAt(),
+			session.getType(),
+			session.getLocation(),
+			session.getLocationDetails(),
+			session.getCourseId(),
+			session.getCurriculumId()
+		);
+
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
+	}
+
+	@PutMapping("/{sessionId}")
+	public ResponseEntity<Void> updateSession(
+		@PathVariable Long sessionId,
+		@Valid @RequestBody SessionUpdate.Request request) {
+		sessionUpdate.updateSession(sessionId, request);
+		return ResponseEntity.noContent().build();
+	}
+
+	@DeleteMapping("/{sessionId}")
+	public ResponseEntity<Void> deleteSession(@PathVariable Long sessionId) {
+		sessionDeletion.deleteSession(sessionId);
+		return ResponseEntity.noContent().build();
 	}
 
 	@GetMapping("/{id}")
@@ -124,18 +120,22 @@ public class SessionController {
 		}, sessionTaskExecutor);
 	}
 
-	@PutMapping("/{sessionId}")
-	public ResponseEntity<Void> updateSession(
-		@PathVariable Long sessionId,
-		@Valid @RequestBody SessionUpdate.Request request) {
-		sessionUpdate.updateSession(sessionId, request);
-		return ResponseEntity.noContent().build();
-	}
-
-	@DeleteMapping("/{sessionId}")
-	public ResponseEntity<Void> deleteSession(@PathVariable Long sessionId) {
-		sessionDeletion.deleteSession(sessionId);
-		return ResponseEntity.noContent().build();
+	@GetMapping
+	public CompletableFuture<ResponseEntity<Page<SessionListRetrieval.SessionListResponse>>> getSessionList(
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "20") int size,
+		@RequestParam(defaultValue = "scheduledAt,desc") String sort,
+		@RequestParam(required = false) SessionType type,
+		@RequestParam(required = false) SessionLocation location,
+		@RequestParam(required = false) Instant startDate,
+		@RequestParam(required = false) Instant endDate
+	) {
+		return CompletableFuture.supplyAsync(() -> {
+			var request = new SessionListRetrieval.SessionListRequest(page, size, sort, type, location, startDate,
+				endDate);
+			Page<SessionListRetrieval.SessionListResponse> response = sessionListRetrieval.getSessionList(request);
+			return ResponseEntity.ok(response);
+		}, sessionTaskExecutor);
 	}
 
 	@GetMapping("/courses/{courseId}")

--- a/src/test/java/me/chan99k/learningmanager/adapter/web/course/CourseCurriculumAdditionControllerTest.java
+++ b/src/test/java/me/chan99k/learningmanager/adapter/web/course/CourseCurriculumAdditionControllerTest.java
@@ -4,7 +4,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,7 +15,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -69,14 +67,10 @@ class CourseCurriculumAdditionControllerTest {
 		given(curriculumCreation.createCurriculum(eq(courseId), any(CurriculumCreation.Request.class)))
 			.willReturn(response);
 
-		MvcResult mvcResult = mockMvc.perform(post("/api/v1/courses/{courseId}/curriculums", courseId)
+		mockMvc.perform(post("/api/v1/courses/{courseId}/curriculums", courseId)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isCreated())
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
 			.andExpect(jsonPath("$.curriculumId").value(101L))
@@ -109,14 +103,10 @@ class CourseCurriculumAdditionControllerTest {
 		given(curriculumCreation.createCurriculum(eq(courseId), any(CurriculumCreation.Request.class)))
 			.willThrow(new AuthorizationException(AuthProblemCode.AUTHORIZATION_REQUIRED));
 
-		MvcResult mvcResult = mockMvc.perform(post("/api/v1/courses/{courseId}/curriculums", courseId)
+		mockMvc.perform(post("/api/v1/courses/{courseId}/curriculums", courseId)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isForbidden())
 			.andExpect(jsonPath("$.code").value(AuthProblemCode.AUTHORIZATION_REQUIRED.getCode()));
 	}
@@ -160,14 +150,10 @@ class CourseCurriculumAdditionControllerTest {
 		given(curriculumCreation.createCurriculum(eq(courseId), any(CurriculumCreation.Request.class)))
 			.willReturn(response);
 
-		MvcResult mvcResult = mockMvc.perform(post("/api/v1/courses/{courseId}/curriculums", courseId)
+		mockMvc.perform(post("/api/v1/courses/{courseId}/curriculums", courseId)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isCreated())
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
 			.andExpect(jsonPath("$.curriculumId").value(102L))
@@ -184,14 +170,10 @@ class CourseCurriculumAdditionControllerTest {
 		given(curriculumCreation.createCurriculum(eq(courseId), any(CurriculumCreation.Request.class)))
 			.willReturn(response);
 
-		MvcResult mvcResult = mockMvc.perform(post("/api/v1/courses/{courseId}/curriculums", courseId)
+		mockMvc.perform(post("/api/v1/courses/{courseId}/curriculums", courseId)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isCreated())
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
 			.andExpect(jsonPath("$.curriculumId").value(103L))
@@ -243,14 +225,10 @@ class CourseCurriculumAdditionControllerTest {
 		given(curriculumCreation.createCurriculum(eq(courseId), any(CurriculumCreation.Request.class)))
 			.willThrow(new AuthorizationException(AuthProblemCode.AUTHORIZATION_REQUIRED));
 
-		MvcResult mvcResult = mockMvc.perform(post("/api/v1/courses/{courseId}/curriculums", courseId)
+		mockMvc.perform(post("/api/v1/courses/{courseId}/curriculums", courseId)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isForbidden());
 	}
 }

--- a/src/test/java/me/chan99k/learningmanager/adapter/web/course/CourseDeletionControllerTest.java
+++ b/src/test/java/me/chan99k/learningmanager/adapter/web/course/CourseDeletionControllerTest.java
@@ -4,7 +4,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,7 +14,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 
 import me.chan99k.learningmanager.adapter.auth.AccessTokenProvider;
 import me.chan99k.learningmanager.adapter.auth.AuthProblemCode;
@@ -58,12 +56,8 @@ class CourseDeletionControllerTest {
 
 		willDoNothing().given(courseDeletion).deleteCourse(courseId);
 
-		MvcResult mvcResult = mockMvc.perform(delete("/api/v1/courses/{courseId}", courseId)
+		mockMvc.perform(delete("/api/v1/courses/{courseId}", courseId)
 				.header("Authorization", "Bearer valid-token"))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isNoContent());
 	}
 
@@ -75,12 +69,8 @@ class CourseDeletionControllerTest {
 		willThrow(new AuthorizationException(AuthProblemCode.AUTHORIZATION_REQUIRED))
 			.given(courseDeletion).deleteCourse(courseId);
 
-		MvcResult mvcResult = mockMvc.perform(delete("/api/v1/courses/{courseId}", courseId)
+		mockMvc.perform(delete("/api/v1/courses/{courseId}", courseId)
 				.header("Authorization", "Bearer valid-token"))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isForbidden())
 			.andExpect(jsonPath("$.code").value(AuthProblemCode.AUTHORIZATION_REQUIRED.getCode()));
 	}
@@ -114,12 +104,8 @@ class CourseDeletionControllerTest {
 		willThrow(new AuthorizationException(AuthProblemCode.AUTHORIZATION_REQUIRED))
 			.given(courseDeletion).deleteCourse(courseId);
 
-		MvcResult mvcResult = mockMvc.perform(delete("/api/v1/courses/{courseId}", courseId)
+		mockMvc.perform(delete("/api/v1/courses/{courseId}", courseId)
 				.header("Authorization", "Bearer valid-token"))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isForbidden());
 	}
 
@@ -131,12 +117,8 @@ class CourseDeletionControllerTest {
 		willThrow(new AuthorizationException(AuthProblemCode.AUTHORIZATION_REQUIRED))
 			.given(courseDeletion).deleteCourse(courseId);
 
-		MvcResult mvcResult = mockMvc.perform(delete("/api/v1/courses/{courseId}", courseId)
+		mockMvc.perform(delete("/api/v1/courses/{courseId}", courseId)
 				.header("Authorization", "Bearer valid-token"))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isForbidden())
 			.andExpect(jsonPath("$.code").value(AuthProblemCode.AUTHORIZATION_REQUIRED.getCode()));
 	}

--- a/src/test/java/me/chan99k/learningmanager/adapter/web/course/CourseInfoUpdateControllerTest.java
+++ b/src/test/java/me/chan99k/learningmanager/adapter/web/course/CourseInfoUpdateControllerTest.java
@@ -4,7 +4,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 
 import java.util.concurrent.Executor;
 
@@ -18,7 +17,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -79,16 +77,11 @@ class CourseInfoUpdateControllerTest {
 		doNothing().when(courseInfoUpdate)
 			.updateCourseInfo(anyLong(), any(CourseInfoUpdate.Request.class));
 
-		// when
-		MvcResult mvcResult = mockMvc.perform(put("/api/v1/courses/{courseId}", 1L)
+		// when & then
+		mockMvc.perform(put("/api/v1/courses/{courseId}", 1L)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		// then
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isOk());
 
 		verify(courseInfoUpdate).updateCourseInfo(1L, request);
@@ -102,16 +95,11 @@ class CourseInfoUpdateControllerTest {
 		doNothing().when(courseInfoUpdate)
 			.updateCourseInfo(anyLong(), any(CourseInfoUpdate.Request.class));
 
-		// when
-		MvcResult mvcResult = mockMvc.perform(put("/api/v1/courses/{courseId}", 1L)
+		// when & then
+		mockMvc.perform(put("/api/v1/courses/{courseId}", 1L)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		// then
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isOk());
 	}
 
@@ -123,16 +111,11 @@ class CourseInfoUpdateControllerTest {
 		doNothing().when(courseInfoUpdate)
 			.updateCourseInfo(anyLong(), any(CourseInfoUpdate.Request.class));
 
-		// when
-		MvcResult mvcResult = mockMvc.perform(put("/api/v1/courses/{courseId}", 1L)
+		// when & then
+		mockMvc.perform(put("/api/v1/courses/{courseId}", 1L)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		// then
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isOk());
 	}
 
@@ -145,16 +128,11 @@ class CourseInfoUpdateControllerTest {
 			.when(courseInfoUpdate)
 			.updateCourseInfo(anyLong(), any(CourseInfoUpdate.Request.class));
 
-		// when
-		MvcResult mvcResult = mockMvc.perform(put("/api/v1/courses/{courseId}", 1L)
+		// when & then
+		mockMvc.perform(put("/api/v1/courses/{courseId}", 1L)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		// then
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isBadRequest());
 	}
 
@@ -167,16 +145,11 @@ class CourseInfoUpdateControllerTest {
 			.when(courseInfoUpdate)
 			.updateCourseInfo(anyLong(), any(CourseInfoUpdate.Request.class));
 
-		// when
-		MvcResult mvcResult = mockMvc.perform(put("/api/v1/courses/{courseId}", 1L)
+		// when & then
+		mockMvc.perform(put("/api/v1/courses/{courseId}", 1L)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		// then
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isUnauthorized())
 			.andExpect(jsonPath("$.code").value(AuthProblemCode.AUTHENTICATION_CONTEXT_NOT_FOUND.getCode()));
 	}
@@ -190,16 +163,11 @@ class CourseInfoUpdateControllerTest {
 			.when(courseInfoUpdate)
 			.updateCourseInfo(anyLong(), any(CourseInfoUpdate.Request.class));
 
-		// when
-		MvcResult mvcResult = mockMvc.perform(put("/api/v1/courses/{courseId}", 1L)
+		// when & then
+		mockMvc.perform(put("/api/v1/courses/{courseId}", 1L)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		// then
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isForbidden())
 			.andExpect(jsonPath("$.code").value(AuthProblemCode.AUTHORIZATION_REQUIRED.getCode()));
 	}
@@ -213,16 +181,11 @@ class CourseInfoUpdateControllerTest {
 			.when(courseInfoUpdate)
 			.updateCourseInfo(anyLong(), any(CourseInfoUpdate.Request.class));
 
-		// when
-		MvcResult mvcResult = mockMvc.perform(put("/api/v1/courses/{courseId}", 1L)
+		// when & then
+		mockMvc.perform(put("/api/v1/courses/{courseId}", 1L)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		// then
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isBadRequest());
 	}
 }

--- a/src/test/java/me/chan99k/learningmanager/adapter/web/course/CourseMemberControllerTest.java
+++ b/src/test/java/me/chan99k/learningmanager/adapter/web/course/CourseMemberControllerTest.java
@@ -4,7 +4,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -19,7 +18,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -86,15 +84,11 @@ class CourseMemberControllerTest {
 		doNothing().when(courseMemberService)
 			.addSingleMember(anyLong(), any(CourseMemberAddition.MemberAdditionItem.class));
 
-		// when
-		MvcResult mvcResult = mockMvc.perform(post("/api/v1/courses/{courseId}/members", 1L)
+		// when & then
+		mockMvc.perform(post("/api/v1/courses/{courseId}/members", 1L)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.totalCount").value(1))
 			.andExpect(jsonPath("$.successCount").value(1))
@@ -133,14 +127,10 @@ class CourseMemberControllerTest {
 		);
 		when(courseMemberService.addMultipleMembers(anyLong(), anyList())).thenReturn(response);
 
-		MvcResult mvcResult = mockMvc.perform(post("/api/v1/courses/{courseId}/members", 1L)
+		mockMvc.perform(post("/api/v1/courses/{courseId}/members", 1L)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isMultiStatus())
 			.andExpect(jsonPath("$.totalCount").value(2))
 			.andExpect(jsonPath("$.successCount").value(2))
@@ -157,14 +147,10 @@ class CourseMemberControllerTest {
 		doThrow(new AuthorizationException(AuthProblemCode.AUTHORIZATION_REQUIRED))
 			.when(courseMemberService).addSingleMember(anyLong(), any(CourseMemberAddition.MemberAdditionItem.class));
 
-		MvcResult mvcResult = mockMvc.perform(post("/api/v1/courses/{courseId}/members", 1L)
+		mockMvc.perform(post("/api/v1/courses/{courseId}/members", 1L)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isForbidden())
 			.andExpect(jsonPath("$.code").value(AuthProblemCode.AUTHORIZATION_REQUIRED.getCode()));
 	}
@@ -179,14 +165,10 @@ class CourseMemberControllerTest {
 		doThrow(new DomainException(CourseProblemCode.COURSE_NOT_FOUND))
 			.when(courseMemberService).addSingleMember(anyLong(), any(CourseMemberAddition.MemberAdditionItem.class));
 
-		MvcResult mvcResult = mockMvc.perform(post("/api/v1/courses/{courseId}/members", 999L)
+		mockMvc.perform(post("/api/v1/courses/{courseId}/members", 999L)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.code").value(CourseProblemCode.COURSE_NOT_FOUND.getCode()));
 	}

--- a/src/test/java/me/chan99k/learningmanager/adapter/web/course/CurriculumUpdateControllerTest.java
+++ b/src/test/java/me/chan99k/learningmanager/adapter/web/course/CurriculumUpdateControllerTest.java
@@ -4,7 +4,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 
 import java.util.concurrent.Executor;
 
@@ -18,7 +17,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -79,16 +77,11 @@ class CurriculumUpdateControllerTest {
 		doNothing().when(curriculumInfoUpdate)
 			.updateCurriculumInfo(anyLong(), anyLong(), any(CurriculumInfoUpdate.Request.class));
 
-		// when
-		MvcResult mvcResult = mockMvc.perform(put("/api/v1/courses/{courseId}/curriculums/{curriculumId}", 1L, 10L)
+		// when & then
+		mockMvc.perform(put("/api/v1/courses/{courseId}/curriculums/{curriculumId}", 1L, 10L)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		// then
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isOk());
 
 		verify(curriculumInfoUpdate).updateCurriculumInfo(1L, 10L, request);
@@ -102,16 +95,11 @@ class CurriculumUpdateControllerTest {
 		doNothing().when(curriculumInfoUpdate)
 			.updateCurriculumInfo(anyLong(), anyLong(), any(CurriculumInfoUpdate.Request.class));
 
-		// when
-		MvcResult mvcResult = mockMvc.perform(put("/api/v1/courses/{courseId}/curriculums/{curriculumId}", 1L, 10L)
+		// when & then
+		mockMvc.perform(put("/api/v1/courses/{courseId}/curriculums/{curriculumId}", 1L, 10L)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		// then
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isOk());
 	}
 
@@ -124,16 +112,11 @@ class CurriculumUpdateControllerTest {
 			.when(curriculumInfoUpdate)
 			.updateCurriculumInfo(anyLong(), anyLong(), any(CurriculumInfoUpdate.Request.class));
 
-		// when
-		MvcResult mvcResult = mockMvc.perform(put("/api/v1/courses/{courseId}/curriculums/{curriculumId}", 1L, 10L)
+		// when & then
+		mockMvc.perform(put("/api/v1/courses/{courseId}/curriculums/{curriculumId}", 1L, 10L)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		// then
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isBadRequest());
 	}
 
@@ -145,16 +128,11 @@ class CurriculumUpdateControllerTest {
 		doNothing().when(curriculumInfoUpdate)
 			.updateCurriculumInfo(anyLong(), anyLong(), any(CurriculumInfoUpdate.Request.class));
 
-		// when
-		MvcResult mvcResult = mockMvc.perform(put("/api/v1/courses/{courseId}/curriculums/{curriculumId}", 1L, 10L)
+		// when & then
+		mockMvc.perform(put("/api/v1/courses/{courseId}/curriculums/{curriculumId}", 1L, 10L)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		// then
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isOk());
 	}
 
@@ -167,16 +145,11 @@ class CurriculumUpdateControllerTest {
 			.when(curriculumInfoUpdate)
 			.updateCurriculumInfo(anyLong(), anyLong(), any(CurriculumInfoUpdate.Request.class));
 
-		// when
-		MvcResult mvcResult = mockMvc.perform(put("/api/v1/courses/{courseId}/curriculums/{curriculumId}", 1L, 10L)
+		// when & then
+		mockMvc.perform(put("/api/v1/courses/{courseId}/curriculums/{curriculumId}", 1L, 10L)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		// then
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isUnauthorized())
 			.andExpect(jsonPath("$.code").value(AuthProblemCode.AUTHENTICATION_CONTEXT_NOT_FOUND.getCode()));
 	}
@@ -190,16 +163,11 @@ class CurriculumUpdateControllerTest {
 			.when(curriculumInfoUpdate)
 			.updateCurriculumInfo(anyLong(), anyLong(), any(CurriculumInfoUpdate.Request.class));
 
-		// when
-		MvcResult mvcResult = mockMvc.perform(put("/api/v1/courses/{courseId}/curriculums/{curriculumId}", 1L, 10L)
+		// when & then
+		mockMvc.perform(put("/api/v1/courses/{courseId}/curriculums/{curriculumId}", 1L, 10L)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		// then
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isForbidden())
 			.andExpect(jsonPath("$.code").value(AuthProblemCode.AUTHORIZATION_REQUIRED.getCode()));
 	}
@@ -213,16 +181,11 @@ class CurriculumUpdateControllerTest {
 			.when(curriculumInfoUpdate)
 			.updateCurriculumInfo(anyLong(), anyLong(), any(CurriculumInfoUpdate.Request.class));
 
-		// when
-		MvcResult mvcResult = mockMvc.perform(put("/api/v1/courses/{courseId}/curriculums/{curriculumId}", 1L, 999L)
+		// when & then
+		mockMvc.perform(put("/api/v1/courses/{courseId}/curriculums/{curriculumId}", 1L, 999L)
 				.header("Authorization", "Bearer valid-token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		// then
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isBadRequest());
 	}
 }

--- a/src/test/java/me/chan99k/learningmanager/adapter/web/member/MemberLoginControllerTest.java
+++ b/src/test/java/me/chan99k/learningmanager/adapter/web/member/MemberLoginControllerTest.java
@@ -3,7 +3,6 @@ package me.chan99k.learningmanager.adapter.web.member;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 
 import java.util.concurrent.Executor;
 
@@ -16,7 +15,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 
 import me.chan99k.learningmanager.adapter.auth.BcryptPasswordEncoder;
 import me.chan99k.learningmanager.adapter.auth.JwtCredentialProvider;
@@ -66,13 +64,9 @@ class MemberLoginControllerTest {
 			}
 			""";
 
-		MvcResult mvcResult = mockMvc.perform(post("/api/v1/members/auth/token")
+		mockMvc.perform(post("/api/v1/members/auth/token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(validRequest))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.accessToken").value("jwt_token_123"));
 	}

--- a/src/test/java/me/chan99k/learningmanager/adapter/web/member/MemberPasswordControllerTest.java
+++ b/src/test/java/me/chan99k/learningmanager/adapter/web/member/MemberPasswordControllerTest.java
@@ -5,7 +5,6 @@ import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 
 import java.util.concurrent.Executor;
 
@@ -18,7 +17,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -75,14 +73,10 @@ class MemberPasswordControllerTest {
 			given(passwordChangeService.changePassword(any(AccountPasswordChange.Request.class)))
 				.willReturn(new AccountPasswordChange.Response());
 
-			MvcResult result = mockMvc.perform(put("/api/v1/members/change-password")
+			mockMvc.perform(put("/api/v1/members/change-password")
 					.contentType(MediaType.APPLICATION_JSON)
 					.header("Authorization", "Bearer mock-token")
 					.content(objectMapper.writeValueAsString(request)))
-				.andExpect(request().asyncStarted())
-				.andReturn();
-
-			mockMvc.perform(asyncDispatch(result))
 				.andExpect(status().isOk());
 		}
 	}
@@ -107,8 +101,7 @@ class MemberPasswordControllerTest {
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andDo(print())
-				.andExpect(request().asyncStarted())
-				.andReturn();
+				.andExpect(status().isOk());
 		}
 
 		@Test
@@ -123,8 +116,7 @@ class MemberPasswordControllerTest {
 			mockMvc.perform(post("/api/v1/members/reset-password")
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
-				.andExpect(request().asyncStarted())
-				.andReturn();
+				.andExpect(status().isBadRequest());
 
 		}
 
@@ -144,13 +136,8 @@ class MemberPasswordControllerTest {
 
 			given(passwordResetService.verifyResetToken(token)).willReturn(response);
 
-			MvcResult result = mockMvc.perform(get("/api/v1/members/reset-password")
+			mockMvc.perform(get("/api/v1/members/reset-password")
 					.param("token", token))
-				.andExpect(request().asyncStarted())
-				.andReturn();
-
-			// 비동기 완료 후 JSON 응답 검증
-			mockMvc.perform(asyncDispatch(result))
 				.andExpect(status().isOk())
 				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
 				.andExpect(jsonPath("$.tokenValid").value(true))
@@ -167,13 +154,8 @@ class MemberPasswordControllerTest {
 			given(passwordResetService.verifyResetToken(invalidToken))
 				.willThrow(new DomainException(MemberProblemCode.INVALID_PASSWORD_RESET_TOKEN));
 
-			MvcResult result = mockMvc.perform(get("/api/v1/members/reset-password")
+			mockMvc.perform(get("/api/v1/members/reset-password")
 					.param("token", invalidToken))
-				.andExpect(request().asyncStarted())
-				.andReturn();
-
-			// 비동기 완료 후 JSON 에러 응답 검증
-			mockMvc.perform(asyncDispatch(result))
 				.andExpect(status().isBadRequest())
 				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
 				.andExpect(jsonPath("$.tokenValid").value(false))
@@ -190,14 +172,9 @@ class MemberPasswordControllerTest {
 			given(passwordResetService.confirmReset(any(AccountPasswordReset.ConfirmResetRequest.class)))
 				.willReturn(new AccountPasswordReset.ConfirmResetResponse());
 
-			MvcResult result = mockMvc.perform(post("/api/v1/members/confirm-reset-password")
+			mockMvc.perform(post("/api/v1/members/confirm-reset-password")
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
-				.andExpect(request().asyncStarted())
-				.andReturn();
-
-			// 비동기 완료 후 성공 상태 검증
-			mockMvc.perform(asyncDispatch(result))
 				.andExpect(status().isNoContent()); // 204 No Content
 		}
 
@@ -226,8 +203,7 @@ class MemberPasswordControllerTest {
 			mockMvc.perform(post("/api/v1/members/confirm-reset-password")
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
-				.andExpect(request().asyncStarted())
-				.andReturn();
+				.andExpect(status().isBadRequest());
 		}
 
 		@Test

--- a/src/test/java/me/chan99k/learningmanager/adapter/web/member/MemberProfileControllerTest.java
+++ b/src/test/java/me/chan99k/learningmanager/adapter/web/member/MemberProfileControllerTest.java
@@ -162,14 +162,10 @@ class MemberProfileControllerTest {
 		given(memberProfileUpdate.updateProfile(eq(5L), any(MemberProfileUpdate.Request.class)))
 			.willReturn(new MemberProfileUpdate.Response(5L));
 
-		MvcResult mvcResult = mockMvc.perform(post("/api/v1/members/profile")
+		mockMvc.perform(post("/api/v1/members/profile")
 				.header("Authorization", "Bearer " + token)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("{\"profileImageUrl\":\"img\",\"selfIntroduction\":\"intro\"}"))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.memberId").value(5));
 

--- a/src/test/java/me/chan99k/learningmanager/adapter/web/member/MemberRegisterControllerTest.java
+++ b/src/test/java/me/chan99k/learningmanager/adapter/web/member/MemberRegisterControllerTest.java
@@ -5,7 +5,6 @@ import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 
 import java.util.concurrent.Executor;
 
@@ -19,7 +18,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -76,16 +74,9 @@ public class MemberRegisterControllerTest {
 			}).given(memberTaskExecutor).execute(any(Runnable.class));
 
 			// 요청 시작 및 결과 검증
-			MvcResult mvcResult = mockMvc.perform(post("/api/v1/members/register")
+			mockMvc.perform(post("/api/v1/members/register")
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
-				.andDo(print())
-				.andExpect(request().asyncStarted())
-				.andReturn();
-
-			// asyncDispatch() : Spring MVC가 관리하는 비동기 요청의 최종 결과를 MockMvc가 가져오는 단계, async 완료 신호를 처리
-			// MockMvc 는 Servlet/DispatcherServlet 내부 상태를 기준으로 async 처리를 완료해야 응답을 읽을 수 있음
-			mockMvc.perform(asyncDispatch(mvcResult))
 				.andDo(print())
 				.andExpect(status().isCreated())
 				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -220,12 +211,8 @@ public class MemberRegisterControllerTest {
 				return null;
 			}).given(memberTaskExecutor).execute(any(Runnable.class));
 
-			MvcResult result = mockMvc.perform(get("/api/v1/members/activate")
+			mockMvc.perform(get("/api/v1/members/activate")
 					.param("token", invalidToken))
-				.andExpect(request().asyncStarted())
-				.andReturn();
-
-			mockMvc.perform(asyncDispatch(result))
 				.andDo(print())
 				.andExpect(status().isInternalServerError());
 		}
@@ -245,12 +232,8 @@ public class MemberRegisterControllerTest {
 				return null;
 			}).given(memberTaskExecutor).execute(any(Runnable.class));
 
-			MvcResult result = mockMvc.perform(get("/api/v1/members/activate")
+			mockMvc.perform(get("/api/v1/members/activate")
 					.param("token", expiredToken))
-				.andExpect(request().asyncStarted())
-				.andReturn();
-
-			mockMvc.perform(asyncDispatch(result))
 				.andDo(print())
 				.andExpect(status().isInternalServerError());
 		}
@@ -270,12 +253,8 @@ public class MemberRegisterControllerTest {
 				return null;
 			}).given(memberTaskExecutor).execute(any(Runnable.class));
 
-			MvcResult result = mockMvc.perform(get("/api/v1/members/activate")
+			mockMvc.perform(get("/api/v1/members/activate")
 					.param("token", nonExistentToken))
-				.andExpect(request().asyncStarted())
-				.andReturn();
-
-			mockMvc.perform(asyncDispatch(result))
 				.andDo(print())
 				.andExpect(status().isInternalServerError());
 		}

--- a/src/test/java/me/chan99k/learningmanager/adapter/web/session/SessionControllerTest.java
+++ b/src/test/java/me/chan99k/learningmanager/adapter/web/session/SessionControllerTest.java
@@ -123,14 +123,10 @@ class SessionControllerTest {
 		given(sessionCreationService.createSession(any(SessionCreation.Request.class)))
 			.willReturn(mockSession);
 
-		MvcResult mvcResult = mockMvc.perform(post("/api/v1/sessions")
+		mockMvc.perform(post("/api/v1/sessions")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andDo(print())
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isCreated())
 			.andExpect(jsonPath("$.id").value(1L))
 			.andExpect(jsonPath("$.title").value("테스트 세션"))
@@ -153,14 +149,10 @@ class SessionControllerTest {
 		given(sessionCreationService.createSession(any(SessionCreation.Request.class)))
 			.willThrow(new AuthorizationException(AuthProblemCode.AUTHORIZATION_REQUIRED));
 
-		MvcResult mvcResult = mockMvc.perform(post("/api/v1/sessions")
+		mockMvc.perform(post("/api/v1/sessions")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andDo(print())
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isForbidden());
 	}
 
@@ -178,14 +170,10 @@ class SessionControllerTest {
 		given(sessionCreationService.createSession(any(SessionCreation.Request.class)))
 			.willThrow(new AuthenticationException(AuthProblemCode.AUTHENTICATION_CONTEXT_NOT_FOUND));
 
-		MvcResult mvcResult = mockMvc.perform(post("/api/v1/sessions")
+		mockMvc.perform(post("/api/v1/sessions")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andDo(print())
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isUnauthorized());
 	}
 
@@ -203,14 +191,10 @@ class SessionControllerTest {
 		given(sessionCreationService.createSession(any(SessionCreation.Request.class)))
 			.willThrow(new DomainException(SessionProblemCode.SESSION_NOT_FOUND));
 
-		MvcResult mvcResult = mockMvc.perform(post("/api/v1/sessions")
+		mockMvc.perform(post("/api/v1/sessions")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andDo(print())
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(mvcResult))
 			.andExpect(status().isBadRequest());
 	}
 


### PR DESCRIPTION
## 💡 Motivation and Context
> `session`, `member`, `course` 도메인에서 상태 변경 요청에 사용되던 `CompletableFuture` 를 제거합니다.

<br>

## 🔨 Modified
> 상태를 변경하는 요청에서 `CompletableFuture` 사용 제거
- `session` 도메인
- `member` 도메인
- `course` 도메인


<br>


### 📋 체크리스트
- [ ] 추가/변경에 대한 테스트
- [ ] 코드 컨벤션

<br>

### 🤟🏻 PR로 완료된 작업
- closes #83